### PR TITLE
fix(ci): revert [*.md] editorconfig to trim_trailing_whitespace only

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,8 +17,6 @@ indent_style = space
 indent_size = 2
 
 [*.md]
-indent_style = space
-indent_size = 2
 trim_trailing_whitespace = false
 
 [.*{rc,ignore}]

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -6,7 +6,7 @@
   "IgnoreDefaults": false,
   "SpacesAfterTabs": false,
   "NoColor": false,
-  "Exclude": ["^LICENSE$", "^public/.*", "^.*/LICENSE$"],
+  "Exclude": ["^LICENSE$", "^public/.*", "^.*/LICENSE$", "^.*\\.md$"],
   "AllowedContentTypes": [],
   "PassedFiles": [],
   "Disable": {

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -6,7 +6,7 @@
   "IgnoreDefaults": false,
   "SpacesAfterTabs": false,
   "NoColor": false,
-  "Exclude": ["^LICENSE$", "^public/.*", "^.*/LICENSE$", "^.*\\.md$"],
+  "Exclude": ["^LICENSE$", "^public/.*"],
   "AllowedContentTypes": [],
   "PassedFiles": [],
   "Disable": {

--- a/packages/confluence-client/README.md
+++ b/packages/confluence-client/README.md
@@ -14,19 +14,19 @@ pnpm add @theholocron/confluence-client
 import { createConfluenceClient } from "@theholocron/confluence-client";
 
 const confluence = createConfluenceClient({
-  baseUrl: "https://myorg.atlassian.net/wiki/rest/api",
-  token: Buffer.from("agent@example.com:your-api-token").toString("base64"),
+	baseUrl: "https://myorg.atlassian.net/wiki/rest/api",
+	token: Buffer.from("agent@example.com:your-api-token").toString("base64"),
 });
 
 // Pages
 const page = await confluence.page.get("123456");
 
 await confluence.page.update("123456", {
-  version: { number: 2 },
-  title: "Updated page title",
-  body: {
-    storage: { value: "<p>New content</p>", representation: "storage" },
-  },
+	version: { number: 2 },
+	title: "Updated page title",
+	body: {
+		storage: { value: "<p>New content</p>", representation: "storage" },
+	},
 });
 ```
 
@@ -36,7 +36,7 @@ Confluence Cloud uses HTTP Basic auth with a base64-encoded `email:apiToken` str
 
 ```ts
 const token = Buffer.from("agent@example.com:your-api-token").toString(
-  "base64",
+	"base64",
 );
 ```
 

--- a/packages/google-client/README.md
+++ b/packages/google-client/README.md
@@ -15,7 +15,7 @@ import { google, googleAuth } from "@theholocron/google-client";
 
 // Service account auth (env vars — see Auth section)
 const authClient = await googleAuth([
-  "https://www.googleapis.com/auth/spreadsheets.readonly",
+	"https://www.googleapis.com/auth/spreadsheets.readonly",
 ]);
 
 // Read a spreadsheet
@@ -56,7 +56,7 @@ GOOGLE_REDIRECT_URI=http://localhost:4000/oauth2callback  # optional
 import { oauth } from "@theholocron/google-client";
 
 const authClient = await oauth([
-  "https://www.googleapis.com/auth/spreadsheets",
+	"https://www.googleapis.com/auth/spreadsheets",
 ]);
 ```
 

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -18,9 +18,9 @@ Factory that returns a `RestClient` — a thin fetch wrapper with bearer/API-key
 import { createRestClient } from "@theholocron/http-client";
 
 const client = createRestClient({
-  baseUrl: "https://api.example.com",
-  token: process.env.EXAMPLE_TOKEN!,
-  vendor: "Example", // prefix for error messages
+	baseUrl: "https://api.example.com",
+	token: process.env.EXAMPLE_TOKEN!,
+	vendor: "Example", // prefix for error messages
 });
 
 const data = await client.request<{ id: string }>("/widgets/42");
@@ -47,12 +47,12 @@ Factory for the standard 4-step token resolution used by all holocron plugins: `
 import { createResolveToken, AuthError } from "@theholocron/http-client";
 
 export const resolveToken = createResolveToken({
-  envName: "HOLOCRON_EXAMPLE_TOKEN",
-  vendorEnvName: "EXAMPLE_TOKEN",
-  keyringService: "example",
-  errorMessage:
-    "no Example token found. Pass --token <TOKEN>, set HOLOCRON_EXAMPLE_TOKEN / EXAMPLE_TOKEN, " +
-    "or run: holocron auth set example <TOKEN>",
+	envName: "HOLOCRON_EXAMPLE_TOKEN",
+	vendorEnvName: "EXAMPLE_TOKEN",
+	keyringService: "example",
+	errorMessage:
+		"no Example token found. Pass --token <TOKEN>, set HOLOCRON_EXAMPLE_TOKEN / EXAMPLE_TOKEN, " +
+		"or run: holocron auth set example <TOKEN>",
 });
 ```
 
@@ -64,11 +64,11 @@ Thrown by `createRestClient` on non-2xx responses and transport failures. Carrie
 import { ProviderApiError } from "@theholocron/http-client";
 
 try {
-  await client.request("/endpoint");
+	await client.request("/endpoint");
 } catch (err) {
-  if (err instanceof ProviderApiError) {
-    console.error(err.status, err.details);
-  }
+	if (err instanceof ProviderApiError) {
+		console.error(err.status, err.details);
+	}
 }
 ```
 

--- a/packages/jira-client/README.md
+++ b/packages/jira-client/README.md
@@ -14,8 +14,8 @@ pnpm add @theholocron/jira-client
 import { createJiraClient } from "@theholocron/jira-client";
 
 const jira = createJiraClient({
-  host: "https://your-org.atlassian.net/rest/api/2",
-  token: Buffer.from(`${email}:${apiToken}`).toString("base64"),
+	host: "https://your-org.atlassian.net/rest/api/2",
+	token: Buffer.from(`${email}:${apiToken}`).toString("base64"),
 });
 
 // Create a ticket
@@ -26,7 +26,7 @@ const issues = await jira.issues.getMany(["PROJ-1", "PROJ-2"]);
 
 // Search with JQL
 const results = await jira.issues.search({
-  jql: "project = PROJ AND status = Open",
+	jql: "project = PROJ AND status = Open",
 });
 
 // Manage versions

--- a/packages/zendesk-client/README.md
+++ b/packages/zendesk-client/README.md
@@ -14,16 +14,16 @@ pnpm add @theholocron/zendesk-client
 import { createZendeskClient, createToken } from "@theholocron/zendesk-client";
 
 const zendesk = createZendeskClient({
-  baseUrl: "https://myorg.zendesk.com",
-  token: createToken("agent@example.com", "your-api-token"),
+	baseUrl: "https://myorg.zendesk.com",
+	token: createToken("agent@example.com", "your-api-token"),
 });
 
 // Tickets
 const ticket = await zendesk.tickets.get(12345);
 const all = await zendesk.tickets.list();
 await zendesk.tickets.create({
-  subject: "Bug report",
-  comment: { body: "Details..." },
+	subject: "Bug report",
+	comment: { body: "Details..." },
 });
 await zendesk.tickets.update(12345, { status: "solved" });
 await zendesk.tickets.delete(12345);
@@ -39,13 +39,13 @@ const field = await zendesk.fields.get(7);
 // Status
 const statuses = await zendesk.status.list();
 await zendesk.status.create({
-  agent_label: "Escalated",
-  status_category: "open",
+	agent_label: "Escalated",
+	status_category: "open",
 });
 
 // Search
 const results = await zendesk.search.query(
-  "type:ticket status:open assignee:me",
+	"type:ticket status:open assignee:me",
 );
 
 // Activities


### PR DESCRIPTION
Aligns with the org pattern — `indent_style` is not enforced for markdown. Files with non-standard indentation use per-file disable comments instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->