### PR TITLE
fix(skill): use rest.request() not rest.get()/rest.post()

### DIFF
--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -193,14 +193,18 @@ import type { <Vendor>Thing } from "./types.js";
 export function <resources>(rest: RestClient) {
 	return {
 		get(id: string): Promise<<Vendor>Thing> {
-			return rest.get(`/<resources>/${id}`);
+			return rest.request<<Vendor>Thing>(`/<resources>/${id}`);
 		},
 
 		create(payload: Partial<<Vendor>Thing>): Promise<<Vendor>Thing> {
-			return rest.post("/<resources>/", payload);
+			return rest.request<<Vendor>Thing>("/<resources>/", {
+				method: "POST",
+				body: payload,
+			});
 		},
 
 		// add more methods as needed
+		// delete: (id: string) => rest.request<void>(`/<resources>/${id}`, { method: "DELETE", expectNoContent: true }),
 	};
 }
 ```


### PR DESCRIPTION
Fixes the resource template — `RestClient` only exposes `request<T>()`, not `.get()` / `.post()`. Code scaffolded from the old template would have had immediate TypeScript compilation errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->