### PR TITLE
chore: bump holocron to alpha.34 and re-sync

### DIFF
--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -22,7 +22,7 @@ Add to `pnpm-workspace.yaml`:
 
 ```yaml
 packages:
-    - packages/<slug>-client
+  - packages/<slug>-client
 ```
 
 Then run `pnpm install` from the repo root.

--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -35,62 +35,62 @@ Then run `pnpm install` from the repo root.
 
 ```json
 {
-	"name": "@theholocron/<slug>-client",
-	"version": "0.0.0",
-	"description": "A TypeScript client for the <Vendor> API",
-	"homepage": "https://github.com/theholocron/clients/tree/main/packages/<slug>-client#readme",
-	"bugs": "https://github.com/theholocron/clients/issues",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/theholocron/clients.git",
-		"directory": "packages/<slug>-client"
-	},
-	"license": "GPL-3.0",
-	"author": "Newton Koumantzelis",
-	"type": "module",
-	"main": "./src/index.ts",
-	"exports": { ".": "./src/index.ts" },
-	"scripts": {
-		"build": "tsdown",
-		"lint": "eslint .",
-		"test": "vitest run",
-		"test:watch": "vitest",
-		"test:coverage": "vitest run --coverage",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@theholocron/http-client": "^0.1.0"
-	},
-	"devDependencies": {
-		"@types/node": "^22.0.0",
-		"@theholocron/eslint-config": "catalog:",
-		"@theholocron/tsconfig": "catalog:",
-		"@theholocron/tsdown-config": "catalog:",
-		"@theholocron/vitest-config": "catalog:",
-		"@vitest/coverage-v8": "catalog:",
-		"@vitest/eslint-plugin": "catalog:",
-		"eslint": "catalog:",
-		"eslint-plugin-n": "catalog:",
-		"globals": "catalog:",
-		"tsdown": "catalog:",
-		"typescript": "catalog:",
-		"vitest": "catalog:"
-	},
-	"publishConfig": {
-		"access": "public",
-		"main": "./dist/index.mjs",
-		"types": "./dist/index.d.mts",
-		"exports": {
-			".": {
-				"types": "./dist/index.d.mts",
-				"import": "./dist/index.mjs",
-				"default": "./dist/index.mjs"
-			}
-		}
-	},
-	"files": ["dist", "README.md"],
-	"engines": { "node": ">=22.0.0" },
-	"releases": "https://github.com/theholocron/clients/releases"
+  "name": "@theholocron/<slug>-client",
+  "version": "0.0.0",
+  "description": "A TypeScript client for the <Vendor> API",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/<slug>-client#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/<slug>-client"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@theholocron/http-client": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "@theholocron/vitest-config": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": ["dist", "README.md"],
+  "engines": { "node": ">=22.0.0" },
+  "releases": "https://github.com/theholocron/clients/releases"
 }
 ```
 
@@ -98,11 +98,11 @@ Then run `pnpm install` from the repo root.
 
 ```json
 {
-	"display": "<Vendor> API Client",
-	"extends": "@theholocron/tsconfig/node-lts",
-	"compilerOptions": { "baseUrl": "./", "outDir": "./dist" },
-	"include": ["src/**/*.ts"],
-	"exclude": ["node_modules", "dist"]
+  "display": "<Vendor> API Client",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "baseUrl": "./", "outDir": "./dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }
 ```
 
@@ -125,16 +125,16 @@ import { library } from "@theholocron/eslint-config/bundles/library";
 
 /** @type {import("eslint").Linter.Config} */
 const config = [
-	...library(),
-	{
-		rules: {
-			// src/ compiles to dist/ via tsdown; files[] lists dist/ so every
-			// relative src/ import is flagged as unpublished. False positive
-			// for the TypeScript src→dist build model.
-			"n/no-unpublished-import": "off",
-		},
-	},
-	{ ignores: ["dist/**", "coverage/**"] },
+  ...library(),
+  {
+    rules: {
+      // src/ compiles to dist/ via tsdown; files[] lists dist/ so every
+      // relative src/ import is flagged as unpublished. False positive
+      // for the TypeScript src→dist build model.
+      "n/no-unpublished-import": "off",
+    },
+  },
+  { ignores: ["dist/**", "coverage/**"] },
 ];
 
 export default config;
@@ -148,8 +148,8 @@ export default config;
 
 ```ts
 export interface <Vendor>Thing {
-	id: string;
-	// ...
+  id: string;
+  // ...
 }
 ```
 
@@ -162,19 +162,19 @@ for dependency injection (required for testing without global stubs).
 import { createRestClient, type RestClient } from "@theholocron/http-client";
 
 export interface <Vendor>ClientOptions {
-	/** API token / key. */
-	token: string;
-	/** Override fetch for testing. Defaults to globalThis.fetch. */
-	fetch?: typeof fetch;
+  /** API token / key. */
+  token: string;
+  /** Override fetch for testing. Defaults to globalThis.fetch. */
+  fetch?: typeof fetch;
 }
 
 export function create<Vendor>RestClient(opts: <Vendor>ClientOptions): RestClient {
-	return createRestClient({
-		baseUrl: "<BASE_URL>",
-		token: opts.token,
-		vendor: "<Vendor>",
-		fetch: opts.fetch,
-	});
+  return createRestClient({
+    baseUrl: "<BASE_URL>",
+    token: opts.token,
+    vendor: "<Vendor>",
+    fetch: opts.fetch,
+  });
 }
 ```
 
@@ -191,21 +191,21 @@ import type { RestClient } from "@theholocron/http-client";
 import type { <Vendor>Thing } from "./types.js";
 
 export function <resources>(rest: RestClient) {
-	return {
-		get(id: string): Promise<<Vendor>Thing> {
-			return rest.request<<Vendor>Thing>(`/<resources>/${id}`);
-		},
+  return {
+    get(id: string): Promise<<Vendor>Thing> {
+      return rest.request<<Vendor>Thing>(`/<resources>/${id}`);
+    },
 
-		create(payload: Partial<<Vendor>Thing>): Promise<<Vendor>Thing> {
-			return rest.request<<Vendor>Thing>("/<resources>/", {
-				method: "POST",
-				body: payload,
-			});
-		},
+    create(payload: Partial<<Vendor>Thing>): Promise<<Vendor>Thing> {
+      return rest.request<<Vendor>Thing>("/<resources>/", {
+        method: "POST",
+        body: payload,
+      });
+    },
 
-		// add more methods as needed
-		// delete: (id: string) => rest.request<void>(`/<resources>/${id}`, { method: "DELETE", expectNoContent: true }),
-	};
+    // add more methods as needed
+    // delete: (id: string) => rest.request<void>(`/<resources>/${id}`, { method: "DELETE", expectNoContent: true }),
+  };
 }
 ```
 
@@ -219,11 +219,11 @@ export type { <Vendor>ClientOptions } from "./client.js";
 export type * from "./types.js";
 
 export function create<Vendor>Client(opts: <Vendor>ClientOptions) {
-	const rest = create<Vendor>RestClient(opts);
-	return {
-		<resources>: <resources>(rest),
-		// add more resource groups here
-	};
+  const rest = create<Vendor>RestClient(opts);
+  return {
+    <resources>: <resources>(rest),
+    // add more resource groups here
+  };
 }
 ```
 
@@ -257,36 +257,36 @@ Every package gets its own `stubFetch` — no global stubs.
 import { vi } from "vitest";
 
 export interface FetchCall {
-	url: string;
-	method: string;
-	headers: Record<string, string>;
-	body: unknown;
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
 }
 
 export function stubFetch(
-	responses: Array<{ status?: number; body?: unknown; text?: string }>,
+  responses: Array<{ status?: number; body?: unknown; text?: string }>,
 ) {
-	const calls: FetchCall[] = [];
-	let i = 0;
-	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
-		const url = typeof input === "string" ? input : input.toString();
-		const body =
-			typeof init?.body === "string"
-				? JSON.parse(init.body)
-				: (init?.body ?? null);
-		calls.push({
-			url,
-			method: (init?.method ?? "GET").toUpperCase(),
-			headers: (init?.headers as Record<string, string>) ?? {},
-			body,
-		});
-		const next = responses[i++] ?? { status: 200, body: {} };
-		const status = next.status ?? 200;
-		if (status === 204) return new Response(null, { status });
-		const text = next.text ?? JSON.stringify(next.body ?? {});
-		return new Response(text, { status });
-	});
-	return { fetch: mock as unknown as typeof fetch, calls };
+  const calls: FetchCall[] = [];
+  let i = 0;
+  const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body =
+      typeof init?.body === "string"
+        ? JSON.parse(init.body)
+        : (init?.body ?? null);
+    calls.push({
+      url,
+      method: (init?.method ?? "GET").toUpperCase(),
+      headers: (init?.headers as Record<string, string>) ?? {},
+      body,
+    });
+    const next = responses[i++] ?? { status: 200, body: {} };
+    const status = next.status ?? 200;
+    if (status === 204) return new Response(null, { status });
+    const text = next.text ?? JSON.stringify(next.body ?? {});
+    return new Response(text, { status });
+  });
+  return { fetch: mock as unknown as typeof fetch, calls };
 }
 ```
 
@@ -302,37 +302,37 @@ import { stubFetch } from "./helpers.js";
 const TOKEN = "test-token";
 
 function makeClient(responses: Parameters<typeof stubFetch>[0]) {
-	const { fetch, calls } = stubFetch(responses);
-	const client = create<Vendor>Client({ token: TOKEN, fetch });
-	return { client, calls };
+  const { fetch, calls } = stubFetch(responses);
+  const client = create<Vendor>Client({ token: TOKEN, fetch });
+  return { client, calls };
 }
 
 describe("<resources>", () => {
-	it("GET /<resources>/:id", async () => {
-		const { client, calls } = makeClient([{ body: { id: "1" } }]);
-		await client.<resources>.get("1");
-		expect(calls[0]?.method).toBe("GET");
-		expect(calls[0]?.url).toContain("/<resources>/1");
-	});
+  it("GET /<resources>/:id", async () => {
+    const { client, calls } = makeClient([{ body: { id: "1" } }]);
+    await client.<resources>.get("1");
+    expect(calls[0]?.method).toBe("GET");
+    expect(calls[0]?.url).toContain("/<resources>/1");
+  });
 
-	it("sends Authorization header", async () => {
-		const { client, calls } = makeClient([{ body: { id: "1" } }]);
-		await client.<resources>.get("1");
-		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
-	});
+  it("sends Authorization header", async () => {
+    const { client, calls } = makeClient([{ body: { id: "1" } }]);
+    await client.<resources>.get("1");
+    expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+  });
 
-	it("POST /<resources>/", async () => {
-		const { client, calls } = makeClient([{ status: 201, body: { id: "2" } }]);
-		await client.<resources>.create({ /* payload */ });
-		expect(calls[0]?.method).toBe("POST");
-	});
+  it("POST /<resources>/", async () => {
+    const { client, calls } = makeClient([{ status: 201, body: { id: "2" } }]);
+    await client.<resources>.create({ /* payload */ });
+    expect(calls[0]?.method).toBe("POST");
+  });
 
-	it("returns undefined on 204", async () => {
-		const { client, calls } = makeClient([{ status: 204 }]);
-		const result = await client.<resources>.create({});
-		expect(result).toBeUndefined();
-		expect(calls).toHaveLength(1);
-	});
+  it("returns undefined on 204", async () => {
+    const { client, calls } = makeClient([{ status: 204 }]);
+    const result = await client.<resources>.create({});
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
 });
 ```
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,8 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
 
 [.*{rc,ignore}]
 indent_style = space

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-14T20:54:44.512Z
+# Synced:  2026-07-14T21:28:34.862Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.508Z
+# Synced:  2026-07-14T21:28:34.855Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Audit

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.510Z
+# Synced:  2026-07-14T21:28:34.858Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: PR Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.506Z
+# Synced:  2026-07-14T21:28:34.854Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.509Z
+# Synced:  2026-07-14T21:28:34.857Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.511Z
+# Synced:  2026-07-14T21:28:34.861Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.501Z
+# Synced:  2026-07-14T21:28:34.845Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.509Z
+# Synced:  2026-07-14T21:28:34.855Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Release

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.507Z
+# Synced:  2026-07-14T21:28:34.854Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.511Z
+# Synced:  2026-07-14T21:28:34.860Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Stale

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.505Z
+# Synced:  2026-07-14T21:28:34.852Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T20:54:44.506Z
+# Synced:  2026-07-14T21:28:34.853Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Typecheck

--- a/packages/confluence-client/README.md
+++ b/packages/confluence-client/README.md
@@ -14,19 +14,19 @@ pnpm add @theholocron/confluence-client
 import { createConfluenceClient } from "@theholocron/confluence-client";
 
 const confluence = createConfluenceClient({
-	baseUrl: "https://myorg.atlassian.net/wiki/rest/api",
-	token: Buffer.from("agent@example.com:your-api-token").toString("base64"),
+  baseUrl: "https://myorg.atlassian.net/wiki/rest/api",
+  token: Buffer.from("agent@example.com:your-api-token").toString("base64"),
 });
 
 // Pages
 const page = await confluence.page.get("123456");
 
 await confluence.page.update("123456", {
-	version: { number: 2 },
-	title: "Updated page title",
-	body: {
-		storage: { value: "<p>New content</p>", representation: "storage" },
-	},
+  version: { number: 2 },
+  title: "Updated page title",
+  body: {
+    storage: { value: "<p>New content</p>", representation: "storage" },
+  },
 });
 ```
 
@@ -36,7 +36,7 @@ Confluence Cloud uses HTTP Basic auth with a base64-encoded `email:apiToken` str
 
 ```ts
 const token = Buffer.from("agent@example.com:your-api-token").toString(
-	"base64",
+  "base64",
 );
 ```
 

--- a/packages/google-client/README.md
+++ b/packages/google-client/README.md
@@ -15,7 +15,7 @@ import { google, googleAuth } from "@theholocron/google-client";
 
 // Service account auth (env vars — see Auth section)
 const authClient = await googleAuth([
-	"https://www.googleapis.com/auth/spreadsheets.readonly",
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
 ]);
 
 // Read a spreadsheet
@@ -56,7 +56,7 @@ GOOGLE_REDIRECT_URI=http://localhost:4000/oauth2callback  # optional
 import { oauth } from "@theholocron/google-client";
 
 const authClient = await oauth([
-	"https://www.googleapis.com/auth/spreadsheets",
+  "https://www.googleapis.com/auth/spreadsheets",
 ]);
 ```
 

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -18,9 +18,9 @@ Factory that returns a `RestClient` — a thin fetch wrapper with bearer/API-key
 import { createRestClient } from "@theholocron/http-client";
 
 const client = createRestClient({
-	baseUrl: "https://api.example.com",
-	token: process.env.EXAMPLE_TOKEN!,
-	vendor: "Example", // prefix for error messages
+  baseUrl: "https://api.example.com",
+  token: process.env.EXAMPLE_TOKEN!,
+  vendor: "Example", // prefix for error messages
 });
 
 const data = await client.request<{ id: string }>("/widgets/42");
@@ -47,12 +47,12 @@ Factory for the standard 4-step token resolution used by all holocron plugins: `
 import { createResolveToken, AuthError } from "@theholocron/http-client";
 
 export const resolveToken = createResolveToken({
-	envName: "HOLOCRON_EXAMPLE_TOKEN",
-	vendorEnvName: "EXAMPLE_TOKEN",
-	keyringService: "example",
-	errorMessage:
-		"no Example token found. Pass --token <TOKEN>, set HOLOCRON_EXAMPLE_TOKEN / EXAMPLE_TOKEN, " +
-		"or run: holocron auth set example <TOKEN>",
+  envName: "HOLOCRON_EXAMPLE_TOKEN",
+  vendorEnvName: "EXAMPLE_TOKEN",
+  keyringService: "example",
+  errorMessage:
+    "no Example token found. Pass --token <TOKEN>, set HOLOCRON_EXAMPLE_TOKEN / EXAMPLE_TOKEN, " +
+    "or run: holocron auth set example <TOKEN>",
 });
 ```
 
@@ -64,11 +64,11 @@ Thrown by `createRestClient` on non-2xx responses and transport failures. Carrie
 import { ProviderApiError } from "@theholocron/http-client";
 
 try {
-	await client.request("/endpoint");
+  await client.request("/endpoint");
 } catch (err) {
-	if (err instanceof ProviderApiError) {
-		console.error(err.status, err.details);
-	}
+  if (err instanceof ProviderApiError) {
+    console.error(err.status, err.details);
+  }
 }
 ```
 

--- a/packages/jira-client/README.md
+++ b/packages/jira-client/README.md
@@ -14,8 +14,8 @@ pnpm add @theholocron/jira-client
 import { createJiraClient } from "@theholocron/jira-client";
 
 const jira = createJiraClient({
-	host: "https://your-org.atlassian.net/rest/api/2",
-	token: Buffer.from(`${email}:${apiToken}`).toString("base64"),
+  host: "https://your-org.atlassian.net/rest/api/2",
+  token: Buffer.from(`${email}:${apiToken}`).toString("base64"),
 });
 
 // Create a ticket
@@ -26,7 +26,7 @@ const issues = await jira.issues.getMany(["PROJ-1", "PROJ-2"]);
 
 // Search with JQL
 const results = await jira.issues.search({
-	jql: "project = PROJ AND status = Open",
+  jql: "project = PROJ AND status = Open",
 });
 
 // Manage versions

--- a/packages/zendesk-client/README.md
+++ b/packages/zendesk-client/README.md
@@ -14,16 +14,16 @@ pnpm add @theholocron/zendesk-client
 import { createZendeskClient, createToken } from "@theholocron/zendesk-client";
 
 const zendesk = createZendeskClient({
-	baseUrl: "https://myorg.zendesk.com",
-	token: createToken("agent@example.com", "your-api-token"),
+  baseUrl: "https://myorg.zendesk.com",
+  token: createToken("agent@example.com", "your-api-token"),
 });
 
 // Tickets
 const ticket = await zendesk.tickets.get(12345);
 const all = await zendesk.tickets.list();
 await zendesk.tickets.create({
-	subject: "Bug report",
-	comment: { body: "Details..." },
+  subject: "Bug report",
+  comment: { body: "Details..." },
 });
 await zendesk.tickets.update(12345, { status: "solved" });
 await zendesk.tickets.delete(12345);
@@ -39,13 +39,13 @@ const field = await zendesk.fields.get(7);
 // Status
 const statuses = await zendesk.status.list();
 await zendesk.status.create({
-	agent_label: "Escalated",
-	status_category: "open",
+  agent_label: "Escalated",
+  status_category: "open",
 });
 
 // Search
 const results = await zendesk.search.query(
-	"type:ticket status:open assignee:me",
+  "type:ticket status:open assignee:me",
 );
 
 // Activities

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,11 +53,11 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.32
-      version: 2.0.0-alpha.32
+      specifier: 2.0.0-alpha.34
+      version: 2.0.0-alpha.34
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.32
-      version: 2.0.0-alpha.32
+      specifier: 2.0.0-alpha.34
+      version: 2.0.0-alpha.34
 
 overrides:
   '@commitlint/config-conventional': ^19.8.1
@@ -83,7 +83,7 @@ importers:
         version: 10.0.1(semantic-release@25.0.6(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.32
+        version: 2.0.0-alpha.34
       '@theholocron/commitlint-config':
         specifier: 'catalog:'
         version: 6.0.1(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
@@ -92,7 +92,7 @@ importers:
         version: 6.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.32(@theholocron/cli@2.0.0-alpha.32)
+        version: 2.0.0-alpha.34(@theholocron/cli@2.0.0-alpha.34)
       '@theholocron/lint-staged-config':
         specifier: 'catalog:'
         version: 6.0.0(husky@9.1.7)(lint-staged@16.4.0)
@@ -1033,8 +1033,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/cli@2.0.0-alpha.32':
-    resolution: {integrity: sha512-lv+hZGdiYNrcUpAiTaU2lK33X7IFVYffxa+i0DHzuDmELNZuV9ZC2Mp+xqlUDplr9qcud+YN6jgSxBG6/N5kAQ==}
+  '@theholocron/cli@2.0.0-alpha.34':
+    resolution: {integrity: sha512-Th9NnOKogK5IcNKhd2UNgcMvWpt243ePrzIE0zfwR+rBo9r9E3qWZp51Zxy21XnH0GpQI3GLWsM6vLla0y5z+A==}
     hasBin: true
 
   '@theholocron/commitlint-config@6.0.1':
@@ -1070,10 +1070,10 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.32':
-    resolution: {integrity: sha512-GMpCB0E3U65SYmSDbLZrQqUofDj62KImuVMAfoFlryh/DPXC7FmQbWUUjj8Oy/JVTyEy6whN+5Sdv7OCrR9ZXg==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.34':
+    resolution: {integrity: sha512-e1iRygwO4UUyJGN5KyrlGl5rJGTcxBzxnT8M/3+Z7RIB3Mdaphuu9qjtgKpbqMsLzQCFEpcPjlx8VfkTM6TL8A==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.32
+      '@theholocron/cli': 2.0.0-alpha.34
 
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
@@ -4239,7 +4239,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/cli@2.0.0-alpha.32':
+  '@theholocron/cli@2.0.0-alpha.34':
     dependencies:
       '@napi-rs/keyring': 1.3.0
       '@theholocron/http-client': 0.1.0
@@ -4261,9 +4261,9 @@ snapshots:
       '@vitest/eslint-plugin': 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.32(@theholocron/cli@2.0.0-alpha.32)':
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.34(@theholocron/cli@2.0.0-alpha.34)':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.32
+      '@theholocron/cli': 2.0.0-alpha.34
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@0.1.0': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.32
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.32
+    '@theholocron/cli': 2.0.0-alpha.34
+    '@theholocron/holocron-plugin-github': 2.0.0-alpha.34
 
 # Shared dep versions used across packages.
 catalog:


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/cli` + `@theholocron/holocron-plugin-github` to `2.0.0-alpha.34`
- Updates `.editorconfig` — `[*.md]` now enforces `indent_style = space` / `indent_size = 2` (spaces are correct for CommonMark; tabs have semantic meaning as code blocks)

## Test plan

- [ ] All CI checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->