### PR TITLE
chore: update labeler mapping with full conventional-commit coverage

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,17 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-14T22:01:38.578Z
+# Synced:  2026-07-15T22:29:40.950Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 
 bug:
   - '^fix'
+
+chore:
+  - '^chore(?!\(deps)'
+
+ci:
+  - '^ci'
 
 dependencies:
   - '^chore\(deps'
@@ -16,5 +22,11 @@ documentation:
 enhancement:
   - '^feat'
 
-github_actions:
-  - '^ci'
+performance:
+  - '^perf'
+
+refactor:
+  - '^refactor'
+
+test:
+  - '^test'


### PR DESCRIPTION
## Summary

- Updates `.github/labeler.yml` with the full conventional-commit mapping: adds `chore`, `ci`, `performance`, `refactor`, `test`; replaces `github_actions` with `ci`

## Test plan

- [ ] CI passes
- [ ] `bookkeeping-pr` correctly labels PRs by conventional commit prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->