### PR TITLE
chore(config): migrate to RepoConfig object and add HolocronConfig type

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,13 +1,21 @@
 import { defineConfig } from "@theholocron/cli";
+import type { HolocronConfig } from "@theholocron/cli";
 
 export default defineConfig({
 	project: {
 		name: "clients",
 		description:
 			"API clients and shared HTTP primitives for theholocron tooling.",
-		repo: "theholocron/clients",
-		repoPolicy: {
-			preset: "strict",
+		repo: {
+			name: "theholocron/clients",
+			protection: "strict",
+			topics: ["api", "api-client", "client", "http-client", "nodejs", "rest", "typescript"],
+			properties: {
+				lifecycle: "active",
+				open_source: true,
+				runtime_environment: "node",
+				uses_external_packages: true,
+			},
 		},
 		workflows: [
 			"lint",
@@ -37,4 +45,4 @@ export default defineConfig({
 			},
 		],
 	},
-});
+} satisfies HolocronConfig);

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -9,7 +9,15 @@ export default defineConfig({
 		repo: {
 			name: "theholocron/clients",
 			protection: "strict",
-			topics: ["api", "api-client", "client", "http-client", "nodejs", "rest", "typescript"],
+			topics: [
+				"api",
+				"api-client",
+				"client",
+				"http-client",
+				"nodejs",
+				"rest",
+				"typescript",
+			],
 			properties: {
 				lifecycle: "active",
 				open_source: true,


### PR DESCRIPTION
## Summary

- Migrates `project.repo` from a bare string to the `RepoConfig` object form with `protection`, `topics`, and `properties`
- Drops `project.repoPolicy` (removed from the schema in theholocron/holocron#146)
- Adds `import type { HolocronConfig }` and `satisfies HolocronConfig` for explicit in-file typing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->