### PR TITLE
chore: remove npm version badges from package table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ API clients and shared HTTP primitives used across the Galaxy.
 
 ## Packages
 
-| Package                                                          | Version                                                                                                                             | Description                                                                           |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [`@theholocron/http-client`](./packages/http-client)             | [![npm](https://img.shields.io/npm/v/@theholocron/http-client)](https://www.npmjs.com/package/@theholocron/http-client)             | Shared HTTP primitives — `createRestClient`, `createResolveToken`, `ProviderApiError` |
-| [`@theholocron/jira-client`](./packages/jira-client)             | [![npm](https://img.shields.io/npm/v/@theholocron/jira-client)](https://www.npmjs.com/package/@theholocron/jira-client)             | TypeScript client for the Jira REST API                                               |
-| [`@theholocron/google-client`](./packages/google-client)         | [![npm](https://img.shields.io/npm/v/@theholocron/google-client)](https://www.npmjs.com/package/@theholocron/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
-| [`@theholocron/zendesk-client`](./packages/zendesk-client)       | [![npm](https://img.shields.io/npm/v/@theholocron/zendesk-client)](https://www.npmjs.com/package/@theholocron/zendesk-client)       | TypeScript client for the Zendesk API                                                 |
-| [`@theholocron/confluence-client`](./packages/confluence-client) | [![npm](https://img.shields.io/npm/v/@theholocron/confluence-client)](https://www.npmjs.com/package/@theholocron/confluence-client) | TypeScript client for the Confluence API                                              |
+| Package                                                          | Description                                                                           |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [`@theholocron/http-client`](./packages/http-client)             | Shared HTTP primitives — `createRestClient`, `createResolveToken`, `ProviderApiError` |
+| [`@theholocron/jira-client`](./packages/jira-client)             | TypeScript client for the Jira REST API                                               |
+| [`@theholocron/google-client`](./packages/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
+| [`@theholocron/zendesk-client`](./packages/zendesk-client)       | TypeScript client for the Zendesk API                                                 |
+| [`@theholocron/confluence-client`](./packages/confluence-client) | TypeScript client for the Confluence API                                              |
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Removes the `Version` column and npm shields badges from the package table in `README.md`
- Badges drift between releases and duplicate what GitHub's releases page already shows
- Lockstep versioning means all packages share one version anyway — a per-package badge adds no information

## Test plan

- [x] Table renders correctly with just Package and Description columns
- [x] No broken links
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->