### PR TITLE
feat: add @theholocron/github-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ API clients and shared HTTP primitives used across the Galaxy.
 | Package                                                          | Description                                                                           |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [`@theholocron/http-client`](./packages/http-client)             | Shared HTTP primitives — `createRestClient`, `createResolveToken`, `ProviderApiError` |
+| [`@theholocron/github-client`](./packages/github-client)         | TypeScript client for the GitHub REST API                                             |
 | [`@theholocron/jira-client`](./packages/jira-client)             | TypeScript client for the Jira REST API                                               |
 | [`@theholocron/google-client`](./packages/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
 | [`@theholocron/zendesk-client`](./packages/zendesk-client)       | TypeScript client for the Zendesk API                                                 |

--- a/packages/github-client/eslint.config.js
+++ b/packages/github-client/eslint.config.js
@@ -1,0 +1,14 @@
+import { library } from "@theholocron/eslint-config/bundles/library";
+
+/** @type {import("eslint").Linter.Config} */
+const config = [
+	...library(),
+	{
+		rules: {
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+];
+
+export default config;

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "workspace:*"
+    "@theholocron/http-client": "^0.2.3"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/github-client",
+  "version": "0.1.0",
+  "description": "A TypeScript client for the GitHub REST API",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/github-client#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/github-client"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@theholocron/http-client": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "@theholocron/vitest-config": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/github-client/src/__tests__/client.test.ts
+++ b/packages/github-client/src/__tests__/client.test.ts
@@ -15,14 +15,18 @@ describe("createGitHubClient", () => {
 		expect(typeof client.repos.getRepo).toBe("function");
 		expect(typeof client.rulesets.listRulesets).toBe("function");
 		expect(typeof client.secrets.listSecrets).toBe("function");
-		expect(typeof client.security.enableVulnerabilityAlerts).toBe("function");
+		expect(typeof client.security.enableVulnerabilityAlerts).toBe(
+			"function",
+		);
 		expect(typeof client.topics.setTopics).toBe("function");
 		expect(typeof client.user.getCurrentUser).toBe("function");
 		expect(typeof client.workflows.listRuns).toBe("function");
 	});
 
 	it("sends Bearer token and GitHub headers on every request", async () => {
-		const { fetch, calls } = stubFetch([{ body: { login: "newton", name: null, email: null } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { login: "newton", name: null, email: null } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.user.getCurrentUser();
 		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
@@ -31,8 +35,14 @@ describe("createGitHubClient", () => {
 	});
 
 	it("uses a custom baseUrl when provided", async () => {
-		const { fetch, calls } = stubFetch([{ body: { login: "gh-emu", name: null, email: null } }]);
-		const client = createGitHubClient({ token: TOKEN, baseUrl: "https://ghes.example.com", fetch });
+		const { fetch, calls } = stubFetch([
+			{ body: { login: "gh-emu", name: null, email: null } },
+		]);
+		const client = createGitHubClient({
+			token: TOKEN,
+			baseUrl: "https://ghes.example.com",
+			fetch,
+		});
 		await client.user.getCurrentUser();
 		expect(calls[0]?.url).toContain("ghes.example.com");
 	});

--- a/packages/github-client/src/__tests__/client.test.ts
+++ b/packages/github-client/src/__tests__/client.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN } from "./helpers.js";
+
+describe("createGitHubClient", () => {
+	it("exposes all namespaces", () => {
+		const { fetch } = stubFetch([]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		expect(typeof client.branches.protectBranch).toBe("function");
+		expect(typeof client.environments.listEnvironments).toBe("function");
+		expect(typeof client.git.getRef).toBe("function");
+		expect(typeof client.issues.listIssues).toBe("function");
+		expect(typeof client.labels.listLabels).toBe("function");
+		expect(typeof client.properties.setProperties).toBe("function");
+		expect(typeof client.repos.getRepo).toBe("function");
+		expect(typeof client.rulesets.listRulesets).toBe("function");
+		expect(typeof client.secrets.listSecrets).toBe("function");
+		expect(typeof client.security.enableVulnerabilityAlerts).toBe("function");
+		expect(typeof client.topics.setTopics).toBe("function");
+		expect(typeof client.user.getCurrentUser).toBe("function");
+		expect(typeof client.workflows.listRuns).toBe("function");
+	});
+
+	it("sends Bearer token and GitHub headers on every request", async () => {
+		const { fetch, calls } = stubFetch([{ body: { login: "newton", name: null, email: null } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.user.getCurrentUser();
+		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+		expect(calls[0]?.headers.accept).toBe("application/vnd.github+json");
+		expect(calls[0]?.headers["x-github-api-version"]).toBe("2022-11-28");
+	});
+
+	it("uses a custom baseUrl when provided", async () => {
+		const { fetch, calls } = stubFetch([{ body: { login: "gh-emu", name: null, email: null } }]);
+		const client = createGitHubClient({ token: TOKEN, baseUrl: "https://ghes.example.com", fetch });
+		await client.user.getCurrentUser();
+		expect(calls[0]?.url).toContain("ghes.example.com");
+	});
+});

--- a/packages/github-client/src/__tests__/environments.test.ts
+++ b/packages/github-client/src/__tests__/environments.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("environments", () => {
+	it("GET /repos/{owner}/{name}/environments", async () => {
+		const envs = [{ name: "staging" }, { name: "production" }];
+		const { fetch, calls } = stubFetch([{ body: { total_count: 2, environments: envs } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.environments.listEnvironments(REPO);
+		expect(calls[0]?.url).toContain("/environments");
+		expect(result).toEqual(envs);
+	});
+
+	it("PUT /repos/{owner}/{name}/environments/{name}", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.environments.upsertEnvironment(REPO, "staging", { wait_timer: 0 });
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain("/environments/staging");
+	});
+
+	it("DELETE /repos/{owner}/{name}/environments/{name}", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.environments.deleteEnvironment(REPO, "staging");
+		expect(calls[0]?.method).toBe("DELETE");
+		expect(calls[0]?.url).toContain("/environments/staging");
+	});
+});

--- a/packages/github-client/src/__tests__/environments.test.ts
+++ b/packages/github-client/src/__tests__/environments.test.ts
@@ -5,7 +5,9 @@ import { stubFetch, TOKEN, REPO } from "./helpers.js";
 describe("environments", () => {
 	it("GET /repos/{owner}/{name}/environments", async () => {
 		const envs = [{ name: "staging" }, { name: "production" }];
-		const { fetch, calls } = stubFetch([{ body: { total_count: 2, environments: envs } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { total_count: 2, environments: envs } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.environments.listEnvironments(REPO);
 		expect(calls[0]?.url).toContain("/environments");
@@ -15,7 +17,9 @@ describe("environments", () => {
 	it("PUT /repos/{owner}/{name}/environments/{name}", async () => {
 		const { fetch, calls } = stubFetch([{ status: 204 }]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		await client.environments.upsertEnvironment(REPO, "staging", { wait_timer: 0 });
+		await client.environments.upsertEnvironment(REPO, "staging", {
+			wait_timer: 0,
+		});
 		expect(calls[0]?.method).toBe("PUT");
 		expect(calls[0]?.url).toContain("/environments/staging");
 	});

--- a/packages/github-client/src/__tests__/git.test.ts
+++ b/packages/github-client/src/__tests__/git.test.ts
@@ -4,7 +4,9 @@ import { stubFetch, TOKEN, REPO } from "./helpers.js";
 
 describe("git", () => {
 	it("GET /repos/{owner}/{name}/git/ref/heads/{branch}", async () => {
-		const { fetch, calls } = stubFetch([{ body: { ref: "refs/heads/main", object: { sha: "abc123" } } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { ref: "refs/heads/main", object: { sha: "abc123" } } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.git.getRef(REPO, "main");
 		expect(calls[0]?.url).toContain("/git/ref/heads/main");
@@ -12,7 +14,9 @@ describe("git", () => {
 	});
 
 	it("GET /repos/{owner}/{name}/git/commits/{sha}", async () => {
-		const { fetch, calls } = stubFetch([{ body: { sha: "abc123", tree: { sha: "tree123" } } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { sha: "abc123", tree: { sha: "tree123" } } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.git.getCommit(REPO, "abc123");
 		expect(calls[0]?.url).toContain("/git/commits/abc123");
@@ -20,50 +24,82 @@ describe("git", () => {
 	});
 
 	it("GET /repos/{owner}/{name}/git/trees/{sha}?recursive=1", async () => {
-		const { fetch, calls } = stubFetch([{ body: { sha: "tree123", tree: [], truncated: false } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { sha: "tree123", tree: [], truncated: false } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.git.getTree(REPO, "tree123", true);
 		expect(calls[0]?.url).toContain("?recursive=1");
 	});
 
 	it("POST /repos/{owner}/{name}/git/blobs", async () => {
-		const { fetch, calls } = stubFetch([{ body: { sha: "blob123", url: "" } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { sha: "blob123", url: "" } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.git.createBlob(REPO, "hello world");
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/git/blobs");
-		expect(calls[0]?.body).toMatchObject({ content: "hello world", encoding: "utf-8" });
+		expect(calls[0]?.body).toMatchObject({
+			content: "hello world",
+			encoding: "utf-8",
+		});
 		expect(result.sha).toBe("blob123");
 	});
 
 	it("POST /repos/{owner}/{name}/git/trees", async () => {
-		const entry = { path: ".github/workflows/lint.yml", mode: "100644", type: "blob", sha: "blob123" };
-		const { fetch, calls } = stubFetch([{ body: { sha: "newtree", tree: [entry], truncated: false } }]);
+		const entry = {
+			path: ".github/workflows/lint.yml",
+			mode: "100644",
+			type: "blob",
+			sha: "blob123",
+		};
+		const { fetch, calls } = stubFetch([
+			{ body: { sha: "newtree", tree: [entry], truncated: false } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.git.createTree(REPO, [entry], "basetree");
 		expect(calls[0]?.method).toBe("POST");
-		expect(calls[0]?.body).toMatchObject({ base_tree: "basetree", tree: [entry] });
+		expect(calls[0]?.body).toMatchObject({
+			base_tree: "basetree",
+			tree: [entry],
+		});
 	});
 
 	it("POST /repos/{owner}/{name}/git/commits", async () => {
-		const { fetch, calls } = stubFetch([{ body: { sha: "newcommit", tree: { sha: "tree" } } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { sha: "newcommit", tree: { sha: "tree" } } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		await client.git.createCommit(REPO, "chore: sync", "newtree", ["parentsha"]);
+		await client.git.createCommit(REPO, "chore: sync", "newtree", [
+			"parentsha",
+		]);
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/git/commits");
-		expect(calls[0]?.body).toMatchObject({ message: "chore: sync", tree: "newtree", parents: ["parentsha"] });
+		expect(calls[0]?.body).toMatchObject({
+			message: "chore: sync",
+			tree: "newtree",
+			parents: ["parentsha"],
+		});
 	});
 
 	it("POST /repos/{owner}/{name}/git/refs", async () => {
-		const { fetch, calls } = stubFetch([{ body: { ref: "refs/heads/sync", object: { sha: "newcommit" } } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { ref: "refs/heads/sync", object: { sha: "newcommit" } } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.git.createRef(REPO, "refs/heads/sync", "newcommit");
 		expect(calls[0]?.method).toBe("POST");
-		expect(calls[0]?.body).toMatchObject({ ref: "refs/heads/sync", sha: "newcommit" });
+		expect(calls[0]?.body).toMatchObject({
+			ref: "refs/heads/sync",
+			sha: "newcommit",
+		});
 	});
 
 	it("PATCH /repos/{owner}/{name}/git/refs/{ref}", async () => {
-		const { fetch, calls } = stubFetch([{ body: { ref: "refs/heads/sync", object: { sha: "newcommit" } } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { ref: "refs/heads/sync", object: { sha: "newcommit" } } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.git.updateRef(REPO, "heads/sync", "newcommit", true);
 		expect(calls[0]?.method).toBe("PATCH");
@@ -72,9 +108,21 @@ describe("git", () => {
 	});
 
 	it("POST /repos/{owner}/{name}/pulls", async () => {
-		const { fetch, calls } = stubFetch([{ body: { number: 1, html_url: "https://github.com/pr/1", title: "chore: sync" } }]);
+		const { fetch, calls } = stubFetch([
+			{
+				body: {
+					number: 1,
+					html_url: "https://github.com/pr/1",
+					title: "chore: sync",
+				},
+			},
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		const result = await client.git.createPull(REPO, { title: "chore: sync", head: "sync", base: "main" });
+		const result = await client.git.createPull(REPO, {
+			title: "chore: sync",
+			head: "sync",
+			base: "main",
+		});
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/pulls");
 		expect(result.html_url).toBe("https://github.com/pr/1");

--- a/packages/github-client/src/__tests__/git.test.ts
+++ b/packages/github-client/src/__tests__/git.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("git", () => {
+	it("GET /repos/{owner}/{name}/git/ref/heads/{branch}", async () => {
+		const { fetch, calls } = stubFetch([{ body: { ref: "refs/heads/main", object: { sha: "abc123" } } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.git.getRef(REPO, "main");
+		expect(calls[0]?.url).toContain("/git/ref/heads/main");
+		expect(result.object.sha).toBe("abc123");
+	});
+
+	it("GET /repos/{owner}/{name}/git/commits/{sha}", async () => {
+		const { fetch, calls } = stubFetch([{ body: { sha: "abc123", tree: { sha: "tree123" } } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.git.getCommit(REPO, "abc123");
+		expect(calls[0]?.url).toContain("/git/commits/abc123");
+		expect(result.tree.sha).toBe("tree123");
+	});
+
+	it("GET /repos/{owner}/{name}/git/trees/{sha}?recursive=1", async () => {
+		const { fetch, calls } = stubFetch([{ body: { sha: "tree123", tree: [], truncated: false } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.git.getTree(REPO, "tree123", true);
+		expect(calls[0]?.url).toContain("?recursive=1");
+	});
+
+	it("POST /repos/{owner}/{name}/git/blobs", async () => {
+		const { fetch, calls } = stubFetch([{ body: { sha: "blob123", url: "" } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.git.createBlob(REPO, "hello world");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/git/blobs");
+		expect(calls[0]?.body).toMatchObject({ content: "hello world", encoding: "utf-8" });
+		expect(result.sha).toBe("blob123");
+	});
+
+	it("POST /repos/{owner}/{name}/git/trees", async () => {
+		const entry = { path: ".github/workflows/lint.yml", mode: "100644", type: "blob", sha: "blob123" };
+		const { fetch, calls } = stubFetch([{ body: { sha: "newtree", tree: [entry], truncated: false } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.git.createTree(REPO, [entry], "basetree");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.body).toMatchObject({ base_tree: "basetree", tree: [entry] });
+	});
+
+	it("POST /repos/{owner}/{name}/git/commits", async () => {
+		const { fetch, calls } = stubFetch([{ body: { sha: "newcommit", tree: { sha: "tree" } } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.git.createCommit(REPO, "chore: sync", "newtree", ["parentsha"]);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/git/commits");
+		expect(calls[0]?.body).toMatchObject({ message: "chore: sync", tree: "newtree", parents: ["parentsha"] });
+	});
+
+	it("POST /repos/{owner}/{name}/git/refs", async () => {
+		const { fetch, calls } = stubFetch([{ body: { ref: "refs/heads/sync", object: { sha: "newcommit" } } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.git.createRef(REPO, "refs/heads/sync", "newcommit");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.body).toMatchObject({ ref: "refs/heads/sync", sha: "newcommit" });
+	});
+
+	it("PATCH /repos/{owner}/{name}/git/refs/{ref}", async () => {
+		const { fetch, calls } = stubFetch([{ body: { ref: "refs/heads/sync", object: { sha: "newcommit" } } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.git.updateRef(REPO, "heads/sync", "newcommit", true);
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/git/refs/heads/sync");
+		expect(calls[0]?.body).toMatchObject({ sha: "newcommit", force: true });
+	});
+
+	it("POST /repos/{owner}/{name}/pulls", async () => {
+		const { fetch, calls } = stubFetch([{ body: { number: 1, html_url: "https://github.com/pr/1", title: "chore: sync" } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.git.createPull(REPO, { title: "chore: sync", head: "sync", base: "main" });
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/pulls");
+		expect(result.html_url).toBe("https://github.com/pr/1");
+	});
+});

--- a/packages/github-client/src/__tests__/helpers.ts
+++ b/packages/github-client/src/__tests__/helpers.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>) {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body =
+			typeof init?.body === "string" ? JSON.parse(init.body) : (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204) return new Response(null, { status });
+		const text = next.text ?? JSON.stringify(next.body ?? {});
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls };
+}
+
+export const TOKEN = "ghp_test_token";
+export const REPO = "theholocron/test-repo";

--- a/packages/github-client/src/__tests__/helpers.ts
+++ b/packages/github-client/src/__tests__/helpers.ts
@@ -7,13 +7,17 @@ export interface FetchCall {
 	body: unknown;
 }
 
-export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>) {
+export function stubFetch(
+	responses: Array<{ status?: number; body?: unknown; text?: string }>,
+) {
 	const calls: FetchCall[] = [];
 	let i = 0;
 	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 		const url = typeof input === "string" ? input : input.toString();
 		const body =
-			typeof init?.body === "string" ? JSON.parse(init.body) : (init?.body ?? null);
+			typeof init?.body === "string"
+				? JSON.parse(init.body)
+				: (init?.body ?? null);
 		calls.push({
 			url,
 			method: (init?.method ?? "GET").toUpperCase(),

--- a/packages/github-client/src/__tests__/labels.test.ts
+++ b/packages/github-client/src/__tests__/labels.test.ts
@@ -12,13 +12,19 @@ describe("labels", () => {
 		const { fetch, calls } = stubFetch([{ body: RAW_LABELS }]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.labels.listLabels(REPO);
-		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo/labels?per_page=100");
+		expect(calls[0]?.url).toContain(
+			"/repos/theholocron/test-repo/labels?per_page=100",
+		);
 		expect(calls[0]?.method).toBe("GET");
 		expect(result).toEqual(RAW_LABELS);
 	});
 
 	it("POST /repos/{owner}/{name}/labels", async () => {
-		const body = { name: "chore", color: "ededed", description: "Maintenance" };
+		const body = {
+			name: "chore",
+			color: "ededed",
+			description: "Maintenance",
+		};
 		const { fetch, calls } = stubFetch([{ body }]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.labels.createLabel(REPO, body);
@@ -28,7 +34,9 @@ describe("labels", () => {
 	});
 
 	it("PATCH /repos/{owner}/{name}/labels/{name}", async () => {
-		const { fetch, calls } = stubFetch([{ body: { name: "bug", color: "ff0000", description: null } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { name: "bug", color: "ff0000", description: null } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.labels.updateLabel(REPO, "bug", { color: "ff0000" });
 		expect(calls[0]?.method).toBe("PATCH");

--- a/packages/github-client/src/__tests__/labels.test.ts
+++ b/packages/github-client/src/__tests__/labels.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+const RAW_LABELS = [
+	{ name: "bug", color: "d73a4a", description: "Something isn't working" },
+	{ name: "enhancement", color: "a2eeef", description: null },
+];
+
+describe("labels", () => {
+	it("GET /repos/{owner}/{name}/labels?per_page=100", async () => {
+		const { fetch, calls } = stubFetch([{ body: RAW_LABELS }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.labels.listLabels(REPO);
+		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo/labels?per_page=100");
+		expect(calls[0]?.method).toBe("GET");
+		expect(result).toEqual(RAW_LABELS);
+	});
+
+	it("POST /repos/{owner}/{name}/labels", async () => {
+		const body = { name: "chore", color: "ededed", description: "Maintenance" };
+		const { fetch, calls } = stubFetch([{ body }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.labels.createLabel(REPO, body);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/labels");
+		expect(calls[0]?.body).toMatchObject(body);
+	});
+
+	it("PATCH /repos/{owner}/{name}/labels/{name}", async () => {
+		const { fetch, calls } = stubFetch([{ body: { name: "bug", color: "ff0000", description: null } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.labels.updateLabel(REPO, "bug", { color: "ff0000" });
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/labels/bug");
+	});
+
+	it("DELETE /repos/{owner}/{name}/labels/{name}", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.labels.deleteLabel(REPO, "stale-label");
+		expect(calls[0]?.method).toBe("DELETE");
+		expect(calls[0]?.url).toContain("/labels/stale-label");
+	});
+});

--- a/packages/github-client/src/__tests__/properties.test.ts
+++ b/packages/github-client/src/__tests__/properties.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("properties", () => {
+	it("PATCH /repos/{owner}/{name}/properties/values", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.properties.setProperties(REPO, { lifecycle: "active", monorepo: "false" });
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/properties/values");
+		expect(calls[0]?.body).toEqual({
+			properties: [
+				{ property_name: "lifecycle", value: "active" },
+				{ property_name: "monorepo", value: "false" },
+			],
+		});
+	});
+});

--- a/packages/github-client/src/__tests__/properties.test.ts
+++ b/packages/github-client/src/__tests__/properties.test.ts
@@ -6,7 +6,10 @@ describe("properties", () => {
 	it("PATCH /repos/{owner}/{name}/properties/values", async () => {
 		const { fetch, calls } = stubFetch([{ status: 204 }]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		await client.properties.setProperties(REPO, { lifecycle: "active", monorepo: "false" });
+		await client.properties.setProperties(REPO, {
+			lifecycle: "active",
+			monorepo: "false",
+		});
 		expect(calls[0]?.method).toBe("PATCH");
 		expect(calls[0]?.url).toContain("/properties/values");
 		expect(calls[0]?.body).toEqual({

--- a/packages/github-client/src/__tests__/repos.test.ts
+++ b/packages/github-client/src/__tests__/repos.test.ts
@@ -4,7 +4,9 @@ import { stubFetch, TOKEN, REPO } from "./helpers.js";
 
 describe("repos", () => {
 	it("GET /repos/{owner}/{name}", async () => {
-		const { fetch, calls } = stubFetch([{ body: { default_branch: "main", full_name: REPO } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { default_branch: "main", full_name: REPO } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.repos.getRepo(REPO);
 		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo");
@@ -21,7 +23,9 @@ describe("repos", () => {
 	});
 
 	it("GET /repos/{owner}/{name}/contents/{path}", async () => {
-		const { fetch, calls } = stubFetch([{ body: { content: "e30K", encoding: "base64" } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { content: "e30K", encoding: "base64" } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.repos.getContents(REPO, "holocron.config.json");
 		expect(calls[0]?.url).toContain("/contents/holocron.config.json");

--- a/packages/github-client/src/__tests__/repos.test.ts
+++ b/packages/github-client/src/__tests__/repos.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("repos", () => {
+	it("GET /repos/{owner}/{name}", async () => {
+		const { fetch, calls } = stubFetch([{ body: { default_branch: "main", full_name: REPO } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.repos.getRepo(REPO);
+		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo");
+		expect(calls[0]?.method).toBe("GET");
+		expect(result.default_branch).toBe("main");
+	});
+
+	it("PATCH /repos/{owner}/{name} for updateRepo", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.repos.updateRepo(REPO, { allow_squash_merge: true });
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.body).toMatchObject({ allow_squash_merge: true });
+	});
+
+	it("GET /repos/{owner}/{name}/contents/{path}", async () => {
+		const { fetch, calls } = stubFetch([{ body: { content: "e30K", encoding: "base64" } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.repos.getContents(REPO, "holocron.config.json");
+		expect(calls[0]?.url).toContain("/contents/holocron.config.json");
+	});
+});

--- a/packages/github-client/src/__tests__/rulesets.test.ts
+++ b/packages/github-client/src/__tests__/rulesets.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+const RULESET = { id: 1, name: "holocron-default-branch", enforcement: "active" };
+
+describe("rulesets", () => {
+	it("GET /repos/{owner}/{name}/rulesets", async () => {
+		const { fetch, calls } = stubFetch([{ body: [RULESET] }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.rulesets.listRulesets(REPO);
+		expect(calls[0]?.url).toContain("/rulesets");
+		expect(result).toEqual([RULESET]);
+	});
+
+	it("POST /repos/{owner}/{name}/rulesets", async () => {
+		const payload = { name: "holocron-default-branch", enforcement: "active" };
+		const { fetch, calls } = stubFetch([{ body: { ...payload, id: 2 } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.rulesets.createRuleset(REPO, payload);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.body).toMatchObject(payload);
+	});
+
+	it("PUT /repos/{owner}/{name}/rulesets/{id}", async () => {
+		const { fetch, calls } = stubFetch([{ body: RULESET }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.rulesets.updateRuleset(REPO, 1, { enforcement: "evaluate" });
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain("/rulesets/1");
+	});
+});

--- a/packages/github-client/src/__tests__/rulesets.test.ts
+++ b/packages/github-client/src/__tests__/rulesets.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { createGitHubClient } from "../index.js";
 import { stubFetch, TOKEN, REPO } from "./helpers.js";
 
-const RULESET = { id: 1, name: "holocron-default-branch", enforcement: "active" };
+const RULESET = {
+	id: 1,
+	name: "holocron-default-branch",
+	enforcement: "active",
+};
 
 describe("rulesets", () => {
 	it("GET /repos/{owner}/{name}/rulesets", async () => {
@@ -14,7 +18,10 @@ describe("rulesets", () => {
 	});
 
 	it("POST /repos/{owner}/{name}/rulesets", async () => {
-		const payload = { name: "holocron-default-branch", enforcement: "active" };
+		const payload = {
+			name: "holocron-default-branch",
+			enforcement: "active",
+		};
 		const { fetch, calls } = stubFetch([{ body: { ...payload, id: 2 } }]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.rulesets.createRuleset(REPO, payload);
@@ -25,7 +32,9 @@ describe("rulesets", () => {
 	it("PUT /repos/{owner}/{name}/rulesets/{id}", async () => {
 		const { fetch, calls } = stubFetch([{ body: RULESET }]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		await client.rulesets.updateRuleset(REPO, 1, { enforcement: "evaluate" });
+		await client.rulesets.updateRuleset(REPO, 1, {
+			enforcement: "evaluate",
+		});
 		expect(calls[0]?.method).toBe("PUT");
 		expect(calls[0]?.url).toContain("/rulesets/1");
 	});

--- a/packages/github-client/src/__tests__/secrets.test.ts
+++ b/packages/github-client/src/__tests__/secrets.test.ts
@@ -18,7 +18,10 @@ describe("secrets", () => {
 			{ body: { total_count: 1, secrets: [{ name: "DB_URL" }] } },
 		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		await client.secrets.listSecrets(REPO, { kind: "environment", name: "staging" });
+		await client.secrets.listSecrets(REPO, {
+			kind: "environment",
+			name: "staging",
+		});
 		expect(calls[0]?.url).toContain("/environments/staging/secrets");
 	});
 
@@ -27,14 +30,21 @@ describe("secrets", () => {
 			{ body: { total_count: 1, secrets: [{ name: "ORG_SECRET" }] } },
 		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		await client.secrets.listSecrets(REPO, { kind: "organization", org: "theholocron" });
+		await client.secrets.listSecrets(REPO, {
+			kind: "organization",
+			org: "theholocron",
+		});
 		expect(calls[0]?.url).toContain("/orgs/theholocron/actions/secrets");
 	});
 
 	it("GET public key", async () => {
-		const { fetch, calls } = stubFetch([{ body: { key_id: "1", key: "abc" } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { key_id: "1", key: "abc" } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
-		const result = await client.secrets.getPublicKey(REPO, { kind: "repo" });
+		const result = await client.secrets.getPublicKey(REPO, {
+			kind: "repo",
+		});
 		expect(calls[0]?.url).toContain("/secrets/public-key");
 		expect(result.key_id).toBe("1");
 	});

--- a/packages/github-client/src/__tests__/secrets.test.ts
+++ b/packages/github-client/src/__tests__/secrets.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("secrets", () => {
+	it("lists repo secrets", async () => {
+		const { fetch, calls } = stubFetch([
+			{ body: { total_count: 1, secrets: [{ name: "NPM_TOKEN" }] } },
+		]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.secrets.listSecrets(REPO, { kind: "repo" });
+		expect(calls[0]?.url).toContain("/actions/secrets");
+		expect(result).toEqual(["NPM_TOKEN"]);
+	});
+
+	it("lists environment secrets", async () => {
+		const { fetch, calls } = stubFetch([
+			{ body: { total_count: 1, secrets: [{ name: "DB_URL" }] } },
+		]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.secrets.listSecrets(REPO, { kind: "environment", name: "staging" });
+		expect(calls[0]?.url).toContain("/environments/staging/secrets");
+	});
+
+	it("lists org secrets", async () => {
+		const { fetch, calls } = stubFetch([
+			{ body: { total_count: 1, secrets: [{ name: "ORG_SECRET" }] } },
+		]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.secrets.listSecrets(REPO, { kind: "organization", org: "theholocron" });
+		expect(calls[0]?.url).toContain("/orgs/theholocron/actions/secrets");
+	});
+
+	it("GET public key", async () => {
+		const { fetch, calls } = stubFetch([{ body: { key_id: "1", key: "abc" } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.secrets.getPublicKey(REPO, { kind: "repo" });
+		expect(calls[0]?.url).toContain("/secrets/public-key");
+		expect(result.key_id).toBe("1");
+	});
+
+	it("PUT secret", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.secrets.putSecret(REPO, { kind: "repo" }, "MY_SECRET", {
+			encrypted_value: "enc",
+			key_id: "1",
+		});
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain("/secrets/MY_SECRET");
+	});
+
+	it("DELETE secret", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.secrets.deleteSecret(REPO, { kind: "repo" }, "OLD_SECRET");
+		expect(calls[0]?.method).toBe("DELETE");
+		expect(calls[0]?.url).toContain("/secrets/OLD_SECRET");
+	});
+});

--- a/packages/github-client/src/__tests__/security.test.ts
+++ b/packages/github-client/src/__tests__/security.test.ts
@@ -45,7 +45,9 @@ describe("security", () => {
 	});
 
 	it("PATCH code-scanning/default-setup to enable", async () => {
-		const { fetch, calls } = stubFetch([{ body: { run_id: 42, run_url: "https://github.com/run/42" } }]);
+		const { fetch, calls } = stubFetch([
+			{ body: { run_id: 42, run_url: "https://github.com/run/42" } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		const result = await client.security.enableCodeScanning(REPO);
 		expect(calls[0]?.url).toContain("/code-scanning/default-setup");

--- a/packages/github-client/src/__tests__/security.test.ts
+++ b/packages/github-client/src/__tests__/security.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("security", () => {
+	it("PUT vulnerability-alerts", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.security.enableVulnerabilityAlerts(REPO);
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain("/vulnerability-alerts");
+	});
+
+	it("PUT automated-security-fixes", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.security.enableAutomatedSecurityFixes(REPO);
+		expect(calls[0]?.url).toContain("/automated-security-fixes");
+	});
+
+	it("PATCH repo for enableSecretScanning", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.security.enableSecretScanning(REPO);
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.body).toMatchObject({
+			security_and_analysis: { secret_scanning: { status: "enabled" } },
+		});
+	});
+
+	it("PUT private-vulnerability-reporting", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.security.enablePrivateVulnerabilityReporting(REPO);
+		expect(calls[0]?.url).toContain("/private-vulnerability-reporting");
+	});
+
+	it("PATCH repo for enableDependencyGraph", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.security.enableDependencyGraph(REPO);
+		expect(calls[0]?.body).toMatchObject({
+			security_and_analysis: { dependency_graph: { status: "enabled" } },
+		});
+	});
+
+	it("PATCH code-scanning/default-setup to enable", async () => {
+		const { fetch, calls } = stubFetch([{ body: { run_id: 42, run_url: "https://github.com/run/42" } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.security.enableCodeScanning(REPO);
+		expect(calls[0]?.url).toContain("/code-scanning/default-setup");
+		expect(calls[0]?.body).toMatchObject({ state: "configured" });
+		expect(result.run_id).toBe(42);
+	});
+
+	it("PATCH code-scanning/default-setup to disable", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.security.disableDefaultCodeScanning(REPO);
+		expect(calls[0]?.body).toMatchObject({ state: "not-configured" });
+	});
+});

--- a/packages/github-client/src/__tests__/topics.test.ts
+++ b/packages/github-client/src/__tests__/topics.test.ts
@@ -9,6 +9,8 @@ describe("topics", () => {
 		await client.topics.setTopics(REPO, ["cli", "nodejs", "typescript"]);
 		expect(calls[0]?.method).toBe("PUT");
 		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo/topics");
-		expect(calls[0]?.body).toEqual({ names: ["cli", "nodejs", "typescript"] });
+		expect(calls[0]?.body).toEqual({
+			names: ["cli", "nodejs", "typescript"],
+		});
 	});
 });

--- a/packages/github-client/src/__tests__/topics.test.ts
+++ b/packages/github-client/src/__tests__/topics.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("topics", () => {
+	it("PUT /repos/{owner}/{name}/topics", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.topics.setTopics(REPO, ["cli", "nodejs", "typescript"]);
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo/topics");
+		expect(calls[0]?.body).toEqual({ names: ["cli", "nodejs", "typescript"] });
+	});
+});

--- a/packages/github-client/src/branches/branches.ts
+++ b/packages/github-client/src/branches/branches.ts
@@ -1,0 +1,12 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export function branches(rest: RestClient) {
+	return {
+		protectBranch: (repo: string, branch: string, payload: Record<string, unknown>): Promise<void> =>
+			rest.request<void>(
+				`${repoBase(repo)}/branches/${encodeURIComponent(branch)}/protection`,
+				{ method: "PUT", body: payload }
+			),
+	};
+}

--- a/packages/github-client/src/branches/branches.ts
+++ b/packages/github-client/src/branches/branches.ts
@@ -3,10 +3,14 @@ import { repoBase } from "../utils.js";
 
 export function branches(rest: RestClient) {
 	return {
-		protectBranch: (repo: string, branch: string, payload: Record<string, unknown>): Promise<void> =>
+		protectBranch: (
+			repo: string,
+			branch: string,
+			payload: Record<string, unknown>,
+		): Promise<void> =>
 			rest.request<void>(
 				`${repoBase(repo)}/branches/${encodeURIComponent(branch)}/protection`,
-				{ method: "PUT", body: payload }
+				{ method: "PUT", body: payload },
 			),
 	};
 }

--- a/packages/github-client/src/environments/environments.ts
+++ b/packages/github-client/src/environments/environments.ts
@@ -23,19 +23,31 @@ export function environments(rest: RestClient) {
 	return {
 		listEnvironments: (repo: string): Promise<GitHubEnvironment[]> =>
 			rest
-				.request<EnvironmentsListResponse>(`${repoBase(repo)}/environments`)
+				.request<EnvironmentsListResponse>(
+					`${repoBase(repo)}/environments`,
+				)
 				.then((r) => r.environments),
 
-		upsertEnvironment: (repo: string, name: string, body: Record<string, unknown>): Promise<void> =>
-			rest.request<void>(`${repoBase(repo)}/environments/${encodeURIComponent(name)}`, {
-				method: "PUT",
-				body,
-			}),
+		upsertEnvironment: (
+			repo: string,
+			name: string,
+			body: Record<string, unknown>,
+		): Promise<void> =>
+			rest.request<void>(
+				`${repoBase(repo)}/environments/${encodeURIComponent(name)}`,
+				{
+					method: "PUT",
+					body,
+				},
+			),
 
 		deleteEnvironment: (repo: string, name: string): Promise<void> =>
-			rest.request<void>(`${repoBase(repo)}/environments/${encodeURIComponent(name)}`, {
-				method: "DELETE",
-				expectNoContent: true,
-			}),
+			rest.request<void>(
+				`${repoBase(repo)}/environments/${encodeURIComponent(name)}`,
+				{
+					method: "DELETE",
+					expectNoContent: true,
+				},
+			),
 	};
 }

--- a/packages/github-client/src/environments/environments.ts
+++ b/packages/github-client/src/environments/environments.ts
@@ -26,7 +26,7 @@ export function environments(rest: RestClient) {
 				.request<EnvironmentsListResponse>(
 					`${repoBase(repo)}/environments`,
 				)
-				.then((r) => r.environments),
+				.then((r: EnvironmentsListResponse) => r.environments),
 
 		upsertEnvironment: (
 			repo: string,

--- a/packages/github-client/src/environments/environments.ts
+++ b/packages/github-client/src/environments/environments.ts
@@ -1,0 +1,41 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitHubEnvironment {
+	name: string;
+	wait_timer?: number;
+	prevent_self_review?: boolean;
+	protection_rules?: Array<{
+		type: string;
+		reviewers?: Array<{
+			type: "User" | "Team";
+			reviewer: { id: number };
+		}>;
+	}>;
+}
+
+interface EnvironmentsListResponse {
+	total_count: number;
+	environments: GitHubEnvironment[];
+}
+
+export function environments(rest: RestClient) {
+	return {
+		listEnvironments: (repo: string): Promise<GitHubEnvironment[]> =>
+			rest
+				.request<EnvironmentsListResponse>(`${repoBase(repo)}/environments`)
+				.then((r) => r.environments),
+
+		upsertEnvironment: (repo: string, name: string, body: Record<string, unknown>): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/environments/${encodeURIComponent(name)}`, {
+				method: "PUT",
+				body,
+			}),
+
+		deleteEnvironment: (repo: string, name: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/environments/${encodeURIComponent(name)}`, {
+				method: "DELETE",
+				expectNoContent: true,
+			}),
+	};
+}

--- a/packages/github-client/src/git/git.ts
+++ b/packages/github-client/src/git/git.ts
@@ -1,0 +1,116 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitRef {
+	object: { sha: string; type: string; url: string };
+	ref: string;
+	url: string;
+}
+
+export interface GitCommit {
+	sha: string;
+	tree: { sha: string; url: string };
+}
+
+export interface GitTreeItem {
+	path: string;
+	sha: string;
+	type: string;
+	mode?: string;
+	size?: number;
+}
+
+export interface GitTree {
+	sha: string;
+	tree: GitTreeItem[];
+	truncated: boolean;
+}
+
+export interface GitContents {
+	content: string;
+	encoding: string;
+	sha: string;
+	name: string;
+	path: string;
+}
+
+export interface GitBlob {
+	sha: string;
+	url: string;
+}
+
+export interface GitPull {
+	number: number;
+	html_url: string;
+	title: string;
+}
+
+export interface CreatePullInput {
+	title: string;
+	head: string;
+	base: string;
+	body?: string;
+}
+
+export function git(rest: RestClient) {
+	return {
+		getRef: (repo: string, branch: string): Promise<GitRef> =>
+			rest.request<GitRef>(`${repoBase(repo)}/git/ref/heads/${branch}`),
+
+		getCommit: (repo: string, sha: string): Promise<GitCommit> =>
+			rest.request<GitCommit>(`${repoBase(repo)}/git/commits/${sha}`),
+
+		getTree: (repo: string, sha: string, recursive = false): Promise<GitTree> =>
+			rest.request<GitTree>(
+				`${repoBase(repo)}/git/trees/${sha}${recursive ? "?recursive=1" : ""}`
+			),
+
+		getContents: (repo: string, path: string): Promise<GitContents> =>
+			rest.request<GitContents>(`${repoBase(repo)}/contents/${path}`),
+
+		createBlob: (repo: string, content: string, encoding = "utf-8"): Promise<GitBlob> =>
+			rest.request<GitBlob>(`${repoBase(repo)}/git/blobs`, {
+				method: "POST",
+				body: { content, encoding },
+			}),
+
+		createTree: (
+			repo: string,
+			tree: Array<{ path: string; mode: string; type: string; sha: string }>,
+			baseTree?: string
+		): Promise<GitTree> =>
+			rest.request<GitTree>(`${repoBase(repo)}/git/trees`, {
+				method: "POST",
+				body: { base_tree: baseTree, tree },
+			}),
+
+		createCommit: (
+			repo: string,
+			message: string,
+			tree: string,
+			parents: string[]
+		): Promise<GitCommit> =>
+			rest.request<GitCommit>(`${repoBase(repo)}/git/commits`, {
+				method: "POST",
+				body: { message, tree, parents },
+			}),
+
+		createRef: (repo: string, ref: string, sha: string): Promise<GitRef> =>
+			rest.request<GitRef>(`${repoBase(repo)}/git/refs`, {
+				method: "POST",
+				body: { ref, sha },
+			}),
+
+		updateRef: (repo: string, ref: string, sha: string, force = false): Promise<GitRef> =>
+			rest.request<GitRef>(`${repoBase(repo)}/git/refs/${ref}`, {
+				method: "PATCH",
+				body: { sha, force },
+			}),
+
+		createPull: (repo: string, input: CreatePullInput): Promise<GitPull> =>
+			rest.request<GitPull>(`${repoBase(repo)}/pulls`, {
+				method: "POST",
+				body: input,
+			}),
+	};
+}

--- a/packages/github-client/src/git/git.ts
+++ b/packages/github-client/src/git/git.ts
@@ -60,15 +60,23 @@ export function git(rest: RestClient) {
 		getCommit: (repo: string, sha: string): Promise<GitCommit> =>
 			rest.request<GitCommit>(`${repoBase(repo)}/git/commits/${sha}`),
 
-		getTree: (repo: string, sha: string, recursive = false): Promise<GitTree> =>
+		getTree: (
+			repo: string,
+			sha: string,
+			recursive = false,
+		): Promise<GitTree> =>
 			rest.request<GitTree>(
-				`${repoBase(repo)}/git/trees/${sha}${recursive ? "?recursive=1" : ""}`
+				`${repoBase(repo)}/git/trees/${sha}${recursive ? "?recursive=1" : ""}`,
 			),
 
 		getContents: (repo: string, path: string): Promise<GitContents> =>
 			rest.request<GitContents>(`${repoBase(repo)}/contents/${path}`),
 
-		createBlob: (repo: string, content: string, encoding = "utf-8"): Promise<GitBlob> =>
+		createBlob: (
+			repo: string,
+			content: string,
+			encoding = "utf-8",
+		): Promise<GitBlob> =>
 			rest.request<GitBlob>(`${repoBase(repo)}/git/blobs`, {
 				method: "POST",
 				body: { content, encoding },
@@ -76,8 +84,13 @@ export function git(rest: RestClient) {
 
 		createTree: (
 			repo: string,
-			tree: Array<{ path: string; mode: string; type: string; sha: string }>,
-			baseTree?: string
+			tree: Array<{
+				path: string;
+				mode: string;
+				type: string;
+				sha: string;
+			}>,
+			baseTree?: string,
 		): Promise<GitTree> =>
 			rest.request<GitTree>(`${repoBase(repo)}/git/trees`, {
 				method: "POST",
@@ -88,7 +101,7 @@ export function git(rest: RestClient) {
 			repo: string,
 			message: string,
 			tree: string,
-			parents: string[]
+			parents: string[],
 		): Promise<GitCommit> =>
 			rest.request<GitCommit>(`${repoBase(repo)}/git/commits`, {
 				method: "POST",
@@ -101,7 +114,12 @@ export function git(rest: RestClient) {
 				body: { ref, sha },
 			}),
 
-		updateRef: (repo: string, ref: string, sha: string, force = false): Promise<GitRef> =>
+		updateRef: (
+			repo: string,
+			ref: string,
+			sha: string,
+			force = false,
+		): Promise<GitRef> =>
 			rest.request<GitRef>(`${repoBase(repo)}/git/refs/${ref}`, {
 				method: "PATCH",
 				body: { sha, force },

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -1,0 +1,57 @@
+import { createGitHubRestClient, type GitHubClientOptions } from "./utils.js";
+import { branches } from "./branches/branches.js";
+import { environments } from "./environments/environments.js";
+import { git } from "./git/git.js";
+import { issues } from "./issues/issues.js";
+import { labels } from "./labels/labels.js";
+import { properties } from "./properties/properties.js";
+import { repos } from "./repos/repos.js";
+import { rulesets } from "./rulesets/rulesets.js";
+import { secrets } from "./secrets/secrets.js";
+import { security } from "./security/security.js";
+import { topics } from "./topics/topics.js";
+import { user } from "./user/user.js";
+import { workflows } from "./workflows/workflows.js";
+
+export type { GitHubClientOptions } from "./utils.js";
+
+export type { GitHubContents, GitHubRepo } from "./repos/repos.js";
+export type { CodeScanningSetupResult } from "./security/security.js";
+export type { GitHubRuleset } from "./rulesets/rulesets.js";
+export type { GitHubWorkflowRun, WorkflowRunFilter } from "./workflows/workflows.js";
+export type { GitHubPublicKey, SecretScope } from "./secrets/secrets.js";
+export type { GitHubEnvironment } from "./environments/environments.js";
+export type { GitHubIssue, GitHubMilestone, IssueSearchParams } from "./issues/issues.js";
+export type { GitHubLabel } from "./labels/labels.js";
+export type {
+	CreatePullInput,
+	GitBlob,
+	GitCommit,
+	GitContents,
+	GitPull,
+	GitRef,
+	GitTree,
+	GitTreeItem,
+} from "./git/git.js";
+export type { GitHubUser } from "./user/user.js";
+
+export function createGitHubClient(opts: GitHubClientOptions) {
+	const rest = createGitHubRestClient(opts);
+	return {
+		branches: branches(rest),
+		environments: environments(rest),
+		git: git(rest),
+		issues: issues(rest),
+		labels: labels(rest),
+		properties: properties(rest),
+		repos: repos(rest),
+		rulesets: rulesets(rest),
+		secrets: secrets(rest),
+		security: security(rest),
+		topics: topics(rest),
+		user: user(rest),
+		workflows: workflows(rest),
+	};
+}
+
+export type GitHubClient = ReturnType<typeof createGitHubClient>;

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -18,10 +18,17 @@ export type { GitHubClientOptions } from "./utils.js";
 export type { GitHubContents, GitHubRepo } from "./repos/repos.js";
 export type { CodeScanningSetupResult } from "./security/security.js";
 export type { GitHubRuleset } from "./rulesets/rulesets.js";
-export type { GitHubWorkflowRun, WorkflowRunFilter } from "./workflows/workflows.js";
+export type {
+	GitHubWorkflowRun,
+	WorkflowRunFilter,
+} from "./workflows/workflows.js";
 export type { GitHubPublicKey, SecretScope } from "./secrets/secrets.js";
 export type { GitHubEnvironment } from "./environments/environments.js";
-export type { GitHubIssue, GitHubMilestone, IssueSearchParams } from "./issues/issues.js";
+export type {
+	GitHubIssue,
+	GitHubMilestone,
+	IssueSearchParams,
+} from "./issues/issues.js";
 export type { GitHubLabel } from "./labels/labels.js";
 export type {
 	CreatePullInput,

--- a/packages/github-client/src/issues/issues.ts
+++ b/packages/github-client/src/issues/issues.ts
@@ -1,0 +1,79 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitHubIssue {
+	id: number;
+	number: number;
+	title: string;
+	body?: string | null;
+	state: "open" | "closed";
+	labels: Array<{ name: string }>;
+	assignee: { login: string; name?: string | null; email?: string | null } | null;
+	updated_at: string;
+	html_url: string;
+	pull_request?: unknown;
+}
+
+export interface GitHubMilestone {
+	number: number;
+	title: string;
+}
+
+export interface IssueSearchParams {
+	state?: "open" | "closed" | "all";
+	sort?: string;
+	direction?: string;
+	per_page?: number;
+	filter?: string;
+	assignee?: string;
+}
+
+export function issues(rest: RestClient) {
+	return {
+		listIssues: (repo: string, params: IssueSearchParams = {}): Promise<GitHubIssue[]> => {
+			const qs = new URLSearchParams();
+			if (params.state) qs.set("state", params.state);
+			if (params.sort) qs.set("sort", params.sort);
+			if (params.direction) qs.set("direction", params.direction);
+			if (params.per_page) qs.set("per_page", String(params.per_page));
+			if (params.filter) qs.set("filter", params.filter);
+			if (params.assignee) qs.set("assignee", params.assignee);
+			const q = qs.toString();
+			const path = q ? `${repoBase(repo)}/issues?${q}` : `${repoBase(repo)}/issues`;
+			return rest.request<GitHubIssue[]>(path);
+		},
+
+		getIssue: (repo: string, number: number): Promise<GitHubIssue> =>
+			rest.request<GitHubIssue>(`${repoBase(repo)}/issues/${number}`),
+
+		createIssue: (repo: string, body: Record<string, unknown>): Promise<GitHubIssue> =>
+			rest.request<GitHubIssue>(`${repoBase(repo)}/issues`, { method: "POST", body }),
+
+		updateIssue: (repo: string, number: number, body: Record<string, unknown>): Promise<GitHubIssue> =>
+			rest.request<GitHubIssue>(`${repoBase(repo)}/issues/${number}`, { method: "PATCH", body }),
+
+		addLabels: (repo: string, number: number, labels: string[]): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/issues/${number}/labels`, {
+				method: "POST",
+				body: { labels },
+			}),
+
+		removeLabel: (repo: string, number: number, label: string): Promise<void> =>
+			rest.request<void>(
+				`${repoBase(repo)}/issues/${number}/labels/${encodeURIComponent(label)}`,
+				{ method: "DELETE" }
+			),
+
+		createComment: (repo: string, number: number, body: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/issues/${number}/comments`, {
+				method: "POST",
+				body: { body },
+			}),
+
+		listMilestones: (repo: string, params: { state?: "open" | "closed" | "all" } = {}): Promise<GitHubMilestone[]> => {
+			const qs = new URLSearchParams({ per_page: "100" });
+			if (params.state) qs.set("state", params.state);
+			return rest.request<GitHubMilestone[]>(`${repoBase(repo)}/milestones?${qs.toString()}`);
+		},
+	};
+}

--- a/packages/github-client/src/issues/issues.ts
+++ b/packages/github-client/src/issues/issues.ts
@@ -8,7 +8,11 @@ export interface GitHubIssue {
 	body?: string | null;
 	state: "open" | "closed";
 	labels: Array<{ name: string }>;
-	assignee: { login: string; name?: string | null; email?: string | null } | null;
+	assignee: {
+		login: string;
+		name?: string | null;
+		email?: string | null;
+	} | null;
 	updated_at: string;
 	html_url: string;
 	pull_request?: unknown;
@@ -30,7 +34,10 @@ export interface IssueSearchParams {
 
 export function issues(rest: RestClient) {
 	return {
-		listIssues: (repo: string, params: IssueSearchParams = {}): Promise<GitHubIssue[]> => {
+		listIssues: (
+			repo: string,
+			params: IssueSearchParams = {},
+		): Promise<GitHubIssue[]> => {
 			const qs = new URLSearchParams();
 			if (params.state) qs.set("state", params.state);
 			if (params.sort) qs.set("sort", params.sort);
@@ -39,41 +46,73 @@ export function issues(rest: RestClient) {
 			if (params.filter) qs.set("filter", params.filter);
 			if (params.assignee) qs.set("assignee", params.assignee);
 			const q = qs.toString();
-			const path = q ? `${repoBase(repo)}/issues?${q}` : `${repoBase(repo)}/issues`;
+			const path = q
+				? `${repoBase(repo)}/issues?${q}`
+				: `${repoBase(repo)}/issues`;
 			return rest.request<GitHubIssue[]>(path);
 		},
 
 		getIssue: (repo: string, number: number): Promise<GitHubIssue> =>
 			rest.request<GitHubIssue>(`${repoBase(repo)}/issues/${number}`),
 
-		createIssue: (repo: string, body: Record<string, unknown>): Promise<GitHubIssue> =>
-			rest.request<GitHubIssue>(`${repoBase(repo)}/issues`, { method: "POST", body }),
+		createIssue: (
+			repo: string,
+			body: Record<string, unknown>,
+		): Promise<GitHubIssue> =>
+			rest.request<GitHubIssue>(`${repoBase(repo)}/issues`, {
+				method: "POST",
+				body,
+			}),
 
-		updateIssue: (repo: string, number: number, body: Record<string, unknown>): Promise<GitHubIssue> =>
-			rest.request<GitHubIssue>(`${repoBase(repo)}/issues/${number}`, { method: "PATCH", body }),
+		updateIssue: (
+			repo: string,
+			number: number,
+			body: Record<string, unknown>,
+		): Promise<GitHubIssue> =>
+			rest.request<GitHubIssue>(`${repoBase(repo)}/issues/${number}`, {
+				method: "PATCH",
+				body,
+			}),
 
-		addLabels: (repo: string, number: number, labels: string[]): Promise<void> =>
+		addLabels: (
+			repo: string,
+			number: number,
+			labels: string[],
+		): Promise<void> =>
 			rest.request<void>(`${repoBase(repo)}/issues/${number}/labels`, {
 				method: "POST",
 				body: { labels },
 			}),
 
-		removeLabel: (repo: string, number: number, label: string): Promise<void> =>
+		removeLabel: (
+			repo: string,
+			number: number,
+			label: string,
+		): Promise<void> =>
 			rest.request<void>(
 				`${repoBase(repo)}/issues/${number}/labels/${encodeURIComponent(label)}`,
-				{ method: "DELETE" }
+				{ method: "DELETE" },
 			),
 
-		createComment: (repo: string, number: number, body: string): Promise<void> =>
+		createComment: (
+			repo: string,
+			number: number,
+			body: string,
+		): Promise<void> =>
 			rest.request<void>(`${repoBase(repo)}/issues/${number}/comments`, {
 				method: "POST",
 				body: { body },
 			}),
 
-		listMilestones: (repo: string, params: { state?: "open" | "closed" | "all" } = {}): Promise<GitHubMilestone[]> => {
+		listMilestones: (
+			repo: string,
+			params: { state?: "open" | "closed" | "all" } = {},
+		): Promise<GitHubMilestone[]> => {
 			const qs = new URLSearchParams({ per_page: "100" });
 			if (params.state) qs.set("state", params.state);
-			return rest.request<GitHubMilestone[]>(`${repoBase(repo)}/milestones?${qs.toString()}`);
+			return rest.request<GitHubMilestone[]>(
+				`${repoBase(repo)}/milestones?${qs.toString()}`,
+			);
 		},
 	};
 }

--- a/packages/github-client/src/labels/labels.ts
+++ b/packages/github-client/src/labels/labels.ts
@@ -10,24 +10,38 @@ export interface GitHubLabel {
 export function labels(rest: RestClient) {
 	return {
 		listLabels: (repo: string): Promise<GitHubLabel[]> =>
-			rest.request<GitHubLabel[]>(`${repoBase(repo)}/labels?per_page=100`),
+			rest.request<GitHubLabel[]>(
+				`${repoBase(repo)}/labels?per_page=100`,
+			),
 
-		createLabel: (repo: string, body: { name: string; color: string; description: string }): Promise<GitHubLabel> =>
-			rest.request<GitHubLabel>(`${repoBase(repo)}/labels`, { method: "POST", body }),
+		createLabel: (
+			repo: string,
+			body: { name: string; color: string; description: string },
+		): Promise<GitHubLabel> =>
+			rest.request<GitHubLabel>(`${repoBase(repo)}/labels`, {
+				method: "POST",
+				body,
+			}),
 
 		updateLabel: (
 			repo: string,
 			name: string,
-			body: { color?: string; description?: string }
+			body: { color?: string; description?: string },
 		): Promise<GitHubLabel> =>
-			rest.request<GitHubLabel>(`${repoBase(repo)}/labels/${encodeURIComponent(name)}`, {
-				method: "PATCH",
-				body,
-			}),
+			rest.request<GitHubLabel>(
+				`${repoBase(repo)}/labels/${encodeURIComponent(name)}`,
+				{
+					method: "PATCH",
+					body,
+				},
+			),
 
 		deleteLabel: (repo: string, name: string): Promise<void> =>
-			rest.request<void>(`${repoBase(repo)}/labels/${encodeURIComponent(name)}`, {
-				method: "DELETE",
-			}),
+			rest.request<void>(
+				`${repoBase(repo)}/labels/${encodeURIComponent(name)}`,
+				{
+					method: "DELETE",
+				},
+			),
 	};
 }

--- a/packages/github-client/src/labels/labels.ts
+++ b/packages/github-client/src/labels/labels.ts
@@ -1,0 +1,33 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitHubLabel {
+	name: string;
+	color: string;
+	description: string | null;
+}
+
+export function labels(rest: RestClient) {
+	return {
+		listLabels: (repo: string): Promise<GitHubLabel[]> =>
+			rest.request<GitHubLabel[]>(`${repoBase(repo)}/labels?per_page=100`),
+
+		createLabel: (repo: string, body: { name: string; color: string; description: string }): Promise<GitHubLabel> =>
+			rest.request<GitHubLabel>(`${repoBase(repo)}/labels`, { method: "POST", body }),
+
+		updateLabel: (
+			repo: string,
+			name: string,
+			body: { color?: string; description?: string }
+		): Promise<GitHubLabel> =>
+			rest.request<GitHubLabel>(`${repoBase(repo)}/labels/${encodeURIComponent(name)}`, {
+				method: "PATCH",
+				body,
+			}),
+
+		deleteLabel: (repo: string, name: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/labels/${encodeURIComponent(name)}`, {
+				method: "DELETE",
+			}),
+	};
+}

--- a/packages/github-client/src/properties/properties.ts
+++ b/packages/github-client/src/properties/properties.ts
@@ -3,11 +3,16 @@ import { repoBase } from "../utils.js";
 
 export function properties(rest: RestClient) {
 	return {
-		setProperties: (repo: string, values: Record<string, string>): Promise<void> => {
-			const propertyList = Object.entries(values).map(([property_name, value]) => ({
-				property_name,
-				value,
-			}));
+		setProperties: (
+			repo: string,
+			values: Record<string, string>,
+		): Promise<void> => {
+			const propertyList = Object.entries(values).map(
+				([property_name, value]) => ({
+					property_name,
+					value,
+				}),
+			);
 			return rest.request<void>(`${repoBase(repo)}/properties/values`, {
 				method: "PATCH",
 				body: { properties: propertyList },

--- a/packages/github-client/src/properties/properties.ts
+++ b/packages/github-client/src/properties/properties.ts
@@ -1,0 +1,17 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export function properties(rest: RestClient) {
+	return {
+		setProperties: (repo: string, values: Record<string, string>): Promise<void> => {
+			const propertyList = Object.entries(values).map(([property_name, value]) => ({
+				property_name,
+				value,
+			}));
+			return rest.request<void>(`${repoBase(repo)}/properties/values`, {
+				method: "PATCH",
+				body: { properties: propertyList },
+			});
+		},
+	};
+}

--- a/packages/github-client/src/repos/repos.ts
+++ b/packages/github-client/src/repos/repos.ts
@@ -16,8 +16,14 @@ export function repos(rest: RestClient) {
 		getRepo: (repo: string): Promise<GitHubRepo> =>
 			rest.request<GitHubRepo>(repoBase(repo)),
 
-		updateRepo: (repo: string, settings: Record<string, unknown>): Promise<void> =>
-			rest.request<void>(repoBase(repo), { method: "PATCH", body: settings }),
+		updateRepo: (
+			repo: string,
+			settings: Record<string, unknown>,
+		): Promise<void> =>
+			rest.request<void>(repoBase(repo), {
+				method: "PATCH",
+				body: settings,
+			}),
 
 		getContents: (repo: string, path: string): Promise<GitHubContents> =>
 			rest.request<GitHubContents>(`${repoBase(repo)}/contents/${path}`),

--- a/packages/github-client/src/repos/repos.ts
+++ b/packages/github-client/src/repos/repos.ts
@@ -1,0 +1,25 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitHubRepo {
+	default_branch: string;
+	full_name: string;
+}
+
+export interface GitHubContents {
+	content: string;
+	encoding: string;
+}
+
+export function repos(rest: RestClient) {
+	return {
+		getRepo: (repo: string): Promise<GitHubRepo> =>
+			rest.request<GitHubRepo>(repoBase(repo)),
+
+		updateRepo: (repo: string, settings: Record<string, unknown>): Promise<void> =>
+			rest.request<void>(repoBase(repo), { method: "PATCH", body: settings }),
+
+		getContents: (repo: string, path: string): Promise<GitHubContents> =>
+			rest.request<GitHubContents>(`${repoBase(repo)}/contents/${path}`),
+	};
+}

--- a/packages/github-client/src/rulesets/rulesets.ts
+++ b/packages/github-client/src/rulesets/rulesets.ts
@@ -12,10 +12,23 @@ export function rulesets(rest: RestClient) {
 		listRulesets: (repo: string): Promise<GitHubRuleset[]> =>
 			rest.request<GitHubRuleset[]>(`${repoBase(repo)}/rulesets`),
 
-		createRuleset: (repo: string, payload: Record<string, unknown>): Promise<GitHubRuleset> =>
-			rest.request<GitHubRuleset>(`${repoBase(repo)}/rulesets`, { method: "POST", body: payload }),
+		createRuleset: (
+			repo: string,
+			payload: Record<string, unknown>,
+		): Promise<GitHubRuleset> =>
+			rest.request<GitHubRuleset>(`${repoBase(repo)}/rulesets`, {
+				method: "POST",
+				body: payload,
+			}),
 
-		updateRuleset: (repo: string, id: number, payload: Record<string, unknown>): Promise<GitHubRuleset> =>
-			rest.request<GitHubRuleset>(`${repoBase(repo)}/rulesets/${id}`, { method: "PUT", body: payload }),
+		updateRuleset: (
+			repo: string,
+			id: number,
+			payload: Record<string, unknown>,
+		): Promise<GitHubRuleset> =>
+			rest.request<GitHubRuleset>(`${repoBase(repo)}/rulesets/${id}`, {
+				method: "PUT",
+				body: payload,
+			}),
 	};
 }

--- a/packages/github-client/src/rulesets/rulesets.ts
+++ b/packages/github-client/src/rulesets/rulesets.ts
@@ -1,0 +1,21 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitHubRuleset {
+	id: number;
+	name: string;
+	enforcement: string;
+}
+
+export function rulesets(rest: RestClient) {
+	return {
+		listRulesets: (repo: string): Promise<GitHubRuleset[]> =>
+			rest.request<GitHubRuleset[]>(`${repoBase(repo)}/rulesets`),
+
+		createRuleset: (repo: string, payload: Record<string, unknown>): Promise<GitHubRuleset> =>
+			rest.request<GitHubRuleset>(`${repoBase(repo)}/rulesets`, { method: "POST", body: payload }),
+
+		updateRuleset: (repo: string, id: number, payload: Record<string, unknown>): Promise<GitHubRuleset> =>
+			rest.request<GitHubRuleset>(`${repoBase(repo)}/rulesets/${id}`, { method: "PUT", body: payload }),
+	};
+}

--- a/packages/github-client/src/secrets/secrets.ts
+++ b/packages/github-client/src/secrets/secrets.ts
@@ -35,7 +35,7 @@ export function secrets(rest: RestClient) {
 					`${scopeBase(repo, scope)}/secrets`,
 				)
 				.then((r: SecretsListResponse) =>
-					r.secrets.map((s: { name: string }) => s.name)
+					r.secrets.map((s: { name: string }) => s.name),
 				),
 
 		getPublicKey: (

--- a/packages/github-client/src/secrets/secrets.ts
+++ b/packages/github-client/src/secrets/secrets.ts
@@ -31,17 +31,24 @@ export function secrets(rest: RestClient) {
 	return {
 		listSecrets: (repo: string, scope: SecretScope): Promise<string[]> =>
 			rest
-				.request<SecretsListResponse>(`${scopeBase(repo, scope)}/secrets`)
+				.request<SecretsListResponse>(
+					`${scopeBase(repo, scope)}/secrets`,
+				)
 				.then((r) => r.secrets.map((s) => s.name)),
 
-		getPublicKey: (repo: string, scope: SecretScope): Promise<GitHubPublicKey> =>
-			rest.request<GitHubPublicKey>(`${scopeBase(repo, scope)}/secrets/public-key`),
+		getPublicKey: (
+			repo: string,
+			scope: SecretScope,
+		): Promise<GitHubPublicKey> =>
+			rest.request<GitHubPublicKey>(
+				`${scopeBase(repo, scope)}/secrets/public-key`,
+			),
 
 		putSecret: (
 			repo: string,
 			scope: SecretScope,
 			name: string,
-			body: Record<string, unknown>
+			body: Record<string, unknown>,
 		): Promise<void> =>
 			rest.request<void>(`${scopeBase(repo, scope)}/secrets/${name}`, {
 				method: "PUT",
@@ -49,7 +56,11 @@ export function secrets(rest: RestClient) {
 				expectNoContent: true,
 			}),
 
-		deleteSecret: (repo: string, scope: SecretScope, name: string): Promise<void> =>
+		deleteSecret: (
+			repo: string,
+			scope: SecretScope,
+			name: string,
+		): Promise<void> =>
 			rest.request<void>(`${scopeBase(repo, scope)}/secrets/${name}`, {
 				method: "DELETE",
 				expectNoContent: true,

--- a/packages/github-client/src/secrets/secrets.ts
+++ b/packages/github-client/src/secrets/secrets.ts
@@ -34,7 +34,9 @@ export function secrets(rest: RestClient) {
 				.request<SecretsListResponse>(
 					`${scopeBase(repo, scope)}/secrets`,
 				)
-				.then((r) => r.secrets.map((s) => s.name)),
+				.then((r: SecretsListResponse) =>
+					r.secrets.map((s: { name: string }) => s.name)
+				),
 
 		getPublicKey: (
 			repo: string,

--- a/packages/github-client/src/secrets/secrets.ts
+++ b/packages/github-client/src/secrets/secrets.ts
@@ -1,0 +1,58 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export type SecretScope =
+	| { kind: "repo" }
+	| { kind: "environment"; name: string }
+	| { kind: "organization"; org: string };
+
+export interface GitHubPublicKey {
+	key_id: string;
+	key: string;
+}
+
+interface SecretsListResponse {
+	total_count: number;
+	secrets: Array<{ name: string }>;
+}
+
+function scopeBase(repo: string, scope: SecretScope): string {
+	switch (scope.kind) {
+		case "repo":
+			return `${repoBase(repo)}/actions`;
+		case "environment":
+			return `${repoBase(repo)}/environments/${scope.name}`;
+		case "organization":
+			return `/orgs/${scope.org}/actions`;
+	}
+}
+
+export function secrets(rest: RestClient) {
+	return {
+		listSecrets: (repo: string, scope: SecretScope): Promise<string[]> =>
+			rest
+				.request<SecretsListResponse>(`${scopeBase(repo, scope)}/secrets`)
+				.then((r) => r.secrets.map((s) => s.name)),
+
+		getPublicKey: (repo: string, scope: SecretScope): Promise<GitHubPublicKey> =>
+			rest.request<GitHubPublicKey>(`${scopeBase(repo, scope)}/secrets/public-key`),
+
+		putSecret: (
+			repo: string,
+			scope: SecretScope,
+			name: string,
+			body: Record<string, unknown>
+		): Promise<void> =>
+			rest.request<void>(`${scopeBase(repo, scope)}/secrets/${name}`, {
+				method: "PUT",
+				body,
+				expectNoContent: true,
+			}),
+
+		deleteSecret: (repo: string, scope: SecretScope, name: string): Promise<void> =>
+			rest.request<void>(`${scopeBase(repo, scope)}/secrets/${name}`, {
+				method: "DELETE",
+				expectNoContent: true,
+			}),
+	};
+}

--- a/packages/github-client/src/security/security.ts
+++ b/packages/github-client/src/security/security.ts
@@ -1,0 +1,65 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface CodeScanningSetupResult {
+	run_id: number;
+	run_url: string;
+}
+
+export function security(rest: RestClient) {
+	return {
+		enableVulnerabilityAlerts: (repo: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/vulnerability-alerts`, {
+				method: "PUT",
+				expectNoContent: true,
+			}),
+
+		enableAutomatedSecurityFixes: (repo: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/automated-security-fixes`, {
+				method: "PUT",
+				expectNoContent: true,
+			}),
+
+		enableSecretScanning: (repo: string): Promise<void> =>
+			rest.request<void>(repoBase(repo), {
+				method: "PATCH",
+				body: {
+					security_and_analysis: {
+						secret_scanning: { status: "enabled" },
+						secret_scanning_push_protection: { status: "enabled" },
+						secret_scanning_validity_checks: { status: "enabled" },
+						secret_scanning_non_provider_patterns: { status: "enabled" },
+					},
+				},
+			}),
+
+		enablePrivateVulnerabilityReporting: (repo: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/private-vulnerability-reporting`, {
+				method: "PUT",
+				expectNoContent: true,
+			}),
+
+		enableDependencyGraph: (repo: string): Promise<void> =>
+			rest.request<void>(repoBase(repo), {
+				method: "PATCH",
+				body: {
+					security_and_analysis: {
+						dependency_graph: { status: "enabled" },
+						dependency_graph_autosubmit_action: { status: "enabled" },
+					},
+				},
+			}),
+
+		enableCodeScanning: (repo: string): Promise<CodeScanningSetupResult> =>
+			rest.request<CodeScanningSetupResult>(`${repoBase(repo)}/code-scanning/default-setup`, {
+				method: "PATCH",
+				body: { state: "configured", query_suite: "extended", threat_model: "remote_and_local" },
+			}),
+
+		disableDefaultCodeScanning: (repo: string): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/code-scanning/default-setup`, {
+				method: "PATCH",
+				body: { state: "not-configured" },
+			}),
+	};
+}

--- a/packages/github-client/src/security/security.ts
+++ b/packages/github-client/src/security/security.ts
@@ -28,16 +28,21 @@ export function security(rest: RestClient) {
 						secret_scanning: { status: "enabled" },
 						secret_scanning_push_protection: { status: "enabled" },
 						secret_scanning_validity_checks: { status: "enabled" },
-						secret_scanning_non_provider_patterns: { status: "enabled" },
+						secret_scanning_non_provider_patterns: {
+							status: "enabled",
+						},
 					},
 				},
 			}),
 
 		enablePrivateVulnerabilityReporting: (repo: string): Promise<void> =>
-			rest.request<void>(`${repoBase(repo)}/private-vulnerability-reporting`, {
-				method: "PUT",
-				expectNoContent: true,
-			}),
+			rest.request<void>(
+				`${repoBase(repo)}/private-vulnerability-reporting`,
+				{
+					method: "PUT",
+					expectNoContent: true,
+				},
+			),
 
 		enableDependencyGraph: (repo: string): Promise<void> =>
 			rest.request<void>(repoBase(repo), {
@@ -45,21 +50,33 @@ export function security(rest: RestClient) {
 				body: {
 					security_and_analysis: {
 						dependency_graph: { status: "enabled" },
-						dependency_graph_autosubmit_action: { status: "enabled" },
+						dependency_graph_autosubmit_action: {
+							status: "enabled",
+						},
 					},
 				},
 			}),
 
 		enableCodeScanning: (repo: string): Promise<CodeScanningSetupResult> =>
-			rest.request<CodeScanningSetupResult>(`${repoBase(repo)}/code-scanning/default-setup`, {
-				method: "PATCH",
-				body: { state: "configured", query_suite: "extended", threat_model: "remote_and_local" },
-			}),
+			rest.request<CodeScanningSetupResult>(
+				`${repoBase(repo)}/code-scanning/default-setup`,
+				{
+					method: "PATCH",
+					body: {
+						state: "configured",
+						query_suite: "extended",
+						threat_model: "remote_and_local",
+					},
+				},
+			),
 
 		disableDefaultCodeScanning: (repo: string): Promise<void> =>
-			rest.request<void>(`${repoBase(repo)}/code-scanning/default-setup`, {
-				method: "PATCH",
-				body: { state: "not-configured" },
-			}),
+			rest.request<void>(
+				`${repoBase(repo)}/code-scanning/default-setup`,
+				{
+					method: "PATCH",
+					body: { state: "not-configured" },
+				},
+			),
 	};
 }

--- a/packages/github-client/src/topics/topics.ts
+++ b/packages/github-client/src/topics/topics.ts
@@ -1,0 +1,12 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export function topics(rest: RestClient) {
+	return {
+		setTopics: (repo: string, names: string[]): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/topics`, {
+				method: "PUT",
+				body: { names },
+			}),
+	};
+}

--- a/packages/github-client/src/user/user.ts
+++ b/packages/github-client/src/user/user.ts
@@ -1,0 +1,14 @@
+import type { RestClient } from "../utils.js";
+
+export interface GitHubUser {
+	login: string;
+	name: string | null;
+	email: string | null;
+}
+
+export function user(rest: RestClient) {
+	return {
+		getCurrentUser: (): Promise<GitHubUser> =>
+			rest.request<GitHubUser>("/user"),
+	};
+}

--- a/packages/github-client/src/utils.ts
+++ b/packages/github-client/src/utils.ts
@@ -1,0 +1,28 @@
+import { createRestClient, type RestClient } from "@theholocron/http-client";
+
+export type { RestClient };
+
+export interface GitHubClientOptions {
+	token: string;
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export function createGitHubRestClient(opts: GitHubClientOptions): RestClient {
+	return createRestClient({
+		baseUrl: opts.baseUrl ?? "https://api.github.com",
+		token: opts.token,
+		extraHeaders: {
+			accept: "application/vnd.github+json",
+			"x-github-api-version": "2022-11-28",
+		},
+		vendor: "GitHub",
+		fetch: opts.fetch,
+	});
+}
+
+/** `/repos/owner/name` prefix from a `"owner/name"` repo string. */
+export function repoBase(repo: string): string {
+	const [owner, name] = repo.split("/", 2);
+	return `/repos/${owner}/${name}`;
+}

--- a/packages/github-client/src/workflows/workflows.ts
+++ b/packages/github-client/src/workflows/workflows.ts
@@ -1,0 +1,43 @@
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export interface GitHubWorkflowRun {
+	id: number;
+	name: string | null;
+	display_title: string;
+	head_branch: string;
+	head_sha: string;
+	status: string;
+	conclusion: string | null;
+	html_url: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface WorkflowRunFilter {
+	branch?: string;
+	limit?: number;
+	status?: string;
+}
+
+interface WorkflowRunsResponse {
+	total_count: number;
+	workflow_runs: GitHubWorkflowRun[];
+}
+
+export function workflows(rest: RestClient) {
+	return {
+		listRuns: (repo: string, filter?: WorkflowRunFilter): Promise<GitHubWorkflowRun[]> => {
+			const params = new URLSearchParams();
+			if (filter?.branch) params.set("branch", filter.branch);
+			if (filter?.limit) params.set("per_page", String(filter.limit));
+			if (filter?.status) params.set("status", filter.status);
+			const qs = params.toString();
+			const path = qs ? `${repoBase(repo)}/actions/runs?${qs}` : `${repoBase(repo)}/actions/runs`;
+			return rest.request<WorkflowRunsResponse>(path).then((r) => r.workflow_runs);
+		},
+
+		getRun: (repo: string, id: string | number): Promise<GitHubWorkflowRun> =>
+			rest.request<GitHubWorkflowRun>(`${repoBase(repo)}/actions/runs/${id}`),
+	};
+}

--- a/packages/github-client/src/workflows/workflows.ts
+++ b/packages/github-client/src/workflows/workflows.ts
@@ -27,17 +27,29 @@ interface WorkflowRunsResponse {
 
 export function workflows(rest: RestClient) {
 	return {
-		listRuns: (repo: string, filter?: WorkflowRunFilter): Promise<GitHubWorkflowRun[]> => {
+		listRuns: (
+			repo: string,
+			filter?: WorkflowRunFilter,
+		): Promise<GitHubWorkflowRun[]> => {
 			const params = new URLSearchParams();
 			if (filter?.branch) params.set("branch", filter.branch);
 			if (filter?.limit) params.set("per_page", String(filter.limit));
 			if (filter?.status) params.set("status", filter.status);
 			const qs = params.toString();
-			const path = qs ? `${repoBase(repo)}/actions/runs?${qs}` : `${repoBase(repo)}/actions/runs`;
-			return rest.request<WorkflowRunsResponse>(path).then((r) => r.workflow_runs);
+			const path = qs
+				? `${repoBase(repo)}/actions/runs?${qs}`
+				: `${repoBase(repo)}/actions/runs`;
+			return rest
+				.request<WorkflowRunsResponse>(path)
+				.then((r) => r.workflow_runs);
 		},
 
-		getRun: (repo: string, id: string | number): Promise<GitHubWorkflowRun> =>
-			rest.request<GitHubWorkflowRun>(`${repoBase(repo)}/actions/runs/${id}`),
+		getRun: (
+			repo: string,
+			id: string | number,
+		): Promise<GitHubWorkflowRun> =>
+			rest.request<GitHubWorkflowRun>(
+				`${repoBase(repo)}/actions/runs/${id}`,
+			),
 	};
 }

--- a/packages/github-client/src/workflows/workflows.ts
+++ b/packages/github-client/src/workflows/workflows.ts
@@ -41,7 +41,7 @@ export function workflows(rest: RestClient) {
 				: `${repoBase(repo)}/actions/runs`;
 			return rest
 				.request<WorkflowRunsResponse>(path)
-				.then((r) => r.workflow_runs);
+				.then((r: WorkflowRunsResponse) => r.workflow_runs);
 		},
 
 		getRun: (

--- a/packages/github-client/tsconfig.json
+++ b/packages/github-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/github-client/tsdown.config.ts
+++ b/packages/github-client/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/github-client/vitest.config.ts
+++ b/packages/github-client/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/github-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: workspace:*
-        version: link:../http-client
+        specifier: ^0.2.3
+        version: 0.2.3
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -1123,6 +1123,10 @@ packages:
 
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
+
+  '@theholocron/http-client@0.2.3':
+    resolution: {integrity: sha512-C/39cotDB9Wzps72cO0S05y3yZeFHMWYgmHYlbSVNArLJ+Au6+y4r2E/SuMg+PgFzYay8xp/855tnggpfAmf3w==}
+    engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@6.1.0':
     resolution: {integrity: sha512-vW9yg6zhDTJiFRQDlWP+ReHDRWXuBsO7iXiR7SYYVhqY8EG/YHg7g4VwqXLBoG+cAe7rUlNKj6GXw5hoqaJ51Q==}
@@ -4307,6 +4311,8 @@ snapshots:
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@0.1.0': {}
+
+  '@theholocron/http-client@0.2.3': {}
 
   '@theholocron/lint-staged-config@6.1.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,52 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/github-client:
+    dependencies:
+      '@theholocron/http-client':
+        specifier: workspace:*
+        version: link:../http-client
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 6.1.0(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.6.1)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/google-client:
     dependencies:
       google-auth-library:


### PR DESCRIPTION
## Summary

Adds `@theholocron/github-client` — a standalone TypeScript client for the GitHub REST API, built on `@theholocron/http-client`. This is PR 1 of 2; PR 2 (in `theholocron/holocron`) will update `holocron-plugin-github` and `sync-github.ts` to consume this package.

## What's included

13 feature namespaces exposed via `createGitHubClient(opts)`:

| Namespace | Endpoints covered |
|---|---|
| `user` | `GET /user` |
| `repos` | `GET/PATCH /repos/{o}/{n}`, `GET /contents/{path}` |
| `security` | vulnerability alerts, automated security fixes, secret scanning, private vuln reporting, dependency graph, code scanning |
| `rulesets` | list, create, update |
| `branches` | branch protection |
| `workflows` | list runs, get run |
| `secrets` | repo / environment / org: list, getPublicKey, put, delete |
| `environments` | list, upsert, delete |
| `issues` | list, get, create, update, addLabels, removeLabel, comment, listMilestones |
| `labels` | list, create, update, delete |
| `topics` | setTopics |
| `properties` | setProperties |
| `git` | getRef, getCommit, getTree, getContents, createBlob, createTree, createCommit, createRef, updateRef, createPull |

## Test plan

- [x] 40 tests, 10 test files — stub-fetch, no live API calls
- [x] Typecheck clean
- [x] Lint clean
- [x] Follows zendesk-client/confluence-client pattern exactly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->