### PR TITLE
fix(github-client): add missing README

### DIFF
--- a/packages/github-client/README.md
+++ b/packages/github-client/README.md
@@ -1,0 +1,49 @@
+# @theholocron/github-client
+
+TypeScript client for the GitHub REST API, built on `@theholocron/http-client`.
+
+## Install
+
+```bash
+npm i @theholocron/github-client
+```
+
+## Usage
+
+```ts
+import { createGitHubClient } from "@theholocron/github-client";
+
+const client = createGitHubClient({ token: process.env.GITHUB_TOKEN! });
+
+// Repos
+const repo = await client.repos.getRepo("owner/name");
+
+// Labels
+const labels = await client.labels.listLabels("owner/name");
+await client.labels.createLabel("owner/name", { name: "bug", color: "d73a4a", description: "Something isn't working" });
+
+// Topics
+await client.topics.setTopics("owner/name", ["cli", "nodejs"]);
+
+// Git plumbing (blobs, trees, commits, refs, PRs)
+const ref = await client.git.getRef("owner/name", "main");
+const blob = await client.git.createBlob("owner/name", "file contents");
+```
+
+## Namespaces
+
+| Namespace | Methods |
+|---|---|
+| `user` | `getCurrentUser` |
+| `repos` | `getRepo`, `updateRepo`, `getContents` |
+| `security` | `enableVulnerabilityAlerts`, `enableAutomatedSecurityFixes`, `enableSecretScanning`, `enablePrivateVulnerabilityReporting`, `enableDependencyGraph`, `enableCodeScanning`, `disableDefaultCodeScanning` |
+| `rulesets` | `listRulesets`, `createRuleset`, `updateRuleset` |
+| `branches` | `protectBranch` |
+| `workflows` | `listRuns`, `getRun` |
+| `secrets` | `listSecrets`, `getPublicKey`, `putSecret`, `deleteSecret` |
+| `environments` | `listEnvironments`, `upsertEnvironment`, `deleteEnvironment` |
+| `issues` | `listIssues`, `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones` |
+| `labels` | `listLabels`, `createLabel`, `updateLabel`, `deleteLabel` |
+| `topics` | `setTopics` |
+| `properties` | `setProperties` |
+| `git` | `getRef`, `getCommit`, `getTree`, `getContents`, `createBlob`, `createTree`, `createCommit`, `createRef`, `updateRef`, `createPull` |

--- a/packages/github-client/README.md
+++ b/packages/github-client/README.md
@@ -20,7 +20,11 @@ const repo = await client.repos.getRepo("owner/name");
 
 // Labels
 const labels = await client.labels.listLabels("owner/name");
-await client.labels.createLabel("owner/name", { name: "bug", color: "d73a4a", description: "Something isn't working" });
+await client.labels.createLabel("owner/name", {
+  name: "bug",
+  color: "d73a4a",
+  description: "Something isn't working",
+});
 
 // Topics
 await client.topics.setTopics("owner/name", ["cli", "nodejs"]);
@@ -32,18 +36,18 @@ const blob = await client.git.createBlob("owner/name", "file contents");
 
 ## Namespaces
 
-| Namespace | Methods |
-|---|---|
-| `user` | `getCurrentUser` |
-| `repos` | `getRepo`, `updateRepo`, `getContents` |
-| `security` | `enableVulnerabilityAlerts`, `enableAutomatedSecurityFixes`, `enableSecretScanning`, `enablePrivateVulnerabilityReporting`, `enableDependencyGraph`, `enableCodeScanning`, `disableDefaultCodeScanning` |
-| `rulesets` | `listRulesets`, `createRuleset`, `updateRuleset` |
-| `branches` | `protectBranch` |
-| `workflows` | `listRuns`, `getRun` |
-| `secrets` | `listSecrets`, `getPublicKey`, `putSecret`, `deleteSecret` |
-| `environments` | `listEnvironments`, `upsertEnvironment`, `deleteEnvironment` |
-| `issues` | `listIssues`, `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones` |
-| `labels` | `listLabels`, `createLabel`, `updateLabel`, `deleteLabel` |
-| `topics` | `setTopics` |
-| `properties` | `setProperties` |
-| `git` | `getRef`, `getCommit`, `getTree`, `getContents`, `createBlob`, `createTree`, `createCommit`, `createRef`, `updateRef`, `createPull` |
+| Namespace      | Methods                                                                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user`         | `getCurrentUser`                                                                                                                                                                                        |
+| `repos`        | `getRepo`, `updateRepo`, `getContents`                                                                                                                                                                  |
+| `security`     | `enableVulnerabilityAlerts`, `enableAutomatedSecurityFixes`, `enableSecretScanning`, `enablePrivateVulnerabilityReporting`, `enableDependencyGraph`, `enableCodeScanning`, `disableDefaultCodeScanning` |
+| `rulesets`     | `listRulesets`, `createRuleset`, `updateRuleset`                                                                                                                                                        |
+| `branches`     | `protectBranch`                                                                                                                                                                                         |
+| `workflows`    | `listRuns`, `getRun`                                                                                                                                                                                    |
+| `secrets`      | `listSecrets`, `getPublicKey`, `putSecret`, `deleteSecret`                                                                                                                                              |
+| `environments` | `listEnvironments`, `upsertEnvironment`, `deleteEnvironment`                                                                                                                                            |
+| `issues`       | `listIssues`, `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones`                                                                                   |
+| `labels`       | `listLabels`, `createLabel`, `updateLabel`, `deleteLabel`                                                                                                                                               |
+| `topics`       | `setTopics`                                                                                                                                                                                             |
+| `properties`   | `setProperties`                                                                                                                                                                                         |
+| `git`          | `getRef`, `getCommit`, `getTree`, `getContents`, `createBlob`, `createTree`, `createCommit`, `createRef`, `updateRef`, `createPull`                                                                     |


### PR DESCRIPTION
The `files[]` field in package.json listed README.md but the file was never created. This also re-triggers the release CI so the package publishes with its built dist/ artifacts (the initial publish-initial ran before the build step).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->