### PR TITLE
fix: add github-client to lockstep release and align version

### DIFF
--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -367,7 +367,25 @@ const thing = await client.<resources>.get("id");
 
 ---
 
-## 7. Checklist before opening a PR
+## 7. Register in `.releaserc.json`
+
+Add the new package to the `prepareCmd` array in `.releaserc.json` so it
+gets bumped in every lockstep release. The array is alphabetically sorted:
+
+```json
+['packages/confluence-client','packages/<slug>-client','packages/google-client',...]
+```
+
+Also set the initial `version` in `package.json` to match the current
+lockstep version (check the latest GitHub release tag, e.g. `0.3.1`).
+
+**This is required.** Skipping it means the package is published once by
+`publish-initial` but never included in future releases — it stays frozen
+at the initial version while all other packages advance.
+
+---
+
+## 8. Checklist before opening a PR
 
 - [ ] `pnpm install` — workspace symlink created
 - [ ] `pnpm --filter @theholocron/<slug>-client typecheck` passes
@@ -377,9 +395,11 @@ const thing = await client.<resources>.get("id");
 - [ ] `src/types.ts` covers every shape returned or accepted by implemented methods
 - [ ] Auth header scheme matches the vendor's spec (Bearer / Basic / Token / custom)
 - [ ] `README.md` has a working usage example
+- [ ] `packages/<slug>-client` added to `prepareCmd` in `.releaserc.json`
+- [ ] `version` in `package.json` set to current lockstep version
 - [ ] Run `holocron setup` so `.alexrc.json` stays current
 
-## 8. First publish
+## 9. First publish
 
 New packages need a one-time manual publish before OIDC Trusted Publishing
 takes over. See the root `README.md` for the `holocron npm publish-initial`

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -37,7 +37,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/confluence-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+        "prepareCmd": "node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/confluence-client','packages/github-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
         "publishCmd": "pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}"
       }
     ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,17 @@ Conventions for working on the `theholocron/clients` monorepo.
   lists `dist/`, so every relative `src/` import is flagged. Keep the
   rule off at project level; do not push it to the org config.
 
+## Adding a new client package
+
+Use the `.claude/skills/new-client.md` skill. Two steps beyond the
+scaffolding that are easy to miss:
+
+1. Add `"packages/<slug>-client"` to the `prepareCmd` array in
+   `.releaserc.json` (keep alphabetical order). Omitting this leaves
+   the package frozen at its initial version while all others advance.
+2. Set the initial `version` in `package.json` to match the current
+   lockstep version (check the latest GitHub release tag).
+
 ## Quality
 
 - `pnpm test` — vitest across all packages via Turbo.

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/github-client",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "description": "A TypeScript client for the GitHub REST API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/github-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",


### PR DESCRIPTION
- Adds `packages/github-client` to the `prepareCmd` package list in `.releaserc.json` — it was omitted when the package was added, so the previous release bumped all other packages to `0.3.1` but left `github-client` at `0.1.0` and unpublished with dist artifacts
- Bumps `github-client/package.json` version to `0.3.1` to align with the current lockstep baseline so the next release increments correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->