### PR TITLE
docs: update new-client skill with consumer workspace step

### DIFF
--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -408,7 +408,7 @@ existing `overrides:` block handle deduplication:
 ```yaml
 # pnpm-workspace.yaml in holocron
 catalog:
-  '@theholocron/<slug>-client': ^<version>
+  "@theholocron/<slug>-client": ^<version>
 ```
 
 Then reference it as `catalog:` in the consuming `package.json`.

--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -59,7 +59,7 @@ Then run `pnpm install` from the repo root.
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "^0.1.0"
+    "@theholocron/http-client": "<current-lockstep-version>"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -399,7 +399,25 @@ at the initial version while all other packages advance.
 - [ ] `version` in `package.json` set to current lockstep version
 - [ ] Run `holocron setup` so `.alexrc.json` stays current
 
-## 9. First publish
+## 9. Update the consuming workspace
+
+If the new client will be consumed by `theholocron/holocron` (or
+another workspace), add it to that workspace's catalog and let the
+existing `overrides:` block handle deduplication:
+
+```yaml
+# pnpm-workspace.yaml in holocron
+catalog:
+  '@theholocron/<slug>-client': ^<version>
+```
+
+Then reference it as `catalog:` in the consuming `package.json`.
+No additional `overrides:` entry is needed — the existing
+`@theholocron/http-client` override already covers the transitive dep.
+
+---
+
+## 10. First publish
 
 New packages need a one-time manual publish before OIDC Trusted Publishing
 takes over. See the root `README.md` for the `holocron npm publish-initial`


### PR DESCRIPTION
Two improvements:
- Fixes stale `^0.1.0` http-client version → `<current-lockstep-version>` placeholder
- Adds step 9: update consuming workspace catalog in `pnpm-workspace.yaml`; existing `overrides:` handles dedup automatically
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->