### PR TITLE
feat: add @theholocron/clerk-client

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -37,7 +37,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/confluence-client','packages/github-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+        "prepareCmd": "node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/github-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
         "publishCmd": "pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@semantic-release/git": "^10.0.1",
     "@theholocron/commitlint-config": "catalog:",
     "@theholocron/eslint-config": "catalog:",
+    "@theholocron/semantic-release-config": "catalog:",
     "@theholocron/lint-staged-config": "catalog:",
     "@theholocron/prettier-config": "catalog:",
     "@theholocron/tsconfig": "catalog:",

--- a/packages/clerk-client/README.md
+++ b/packages/clerk-client/README.md
@@ -1,0 +1,48 @@
+# `@theholocron/clerk-client`
+
+TypeScript client for the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+
+## Install
+
+```bash
+pnpm add @theholocron/clerk-client
+```
+
+## Usage
+
+```ts
+import { createClerkClient } from "@theholocron/clerk-client";
+
+const clerk = createClerkClient({ token: process.env.CLERK_SECRET_KEY! });
+
+// List users
+const users = await clerk.users.list({ limit: 10 });
+
+// Get a user by ID
+const user = await clerk.users.get("user_abc123");
+
+// Create a user
+const newUser = await clerk.users.create({
+  first_name: "Jane",
+  last_name: "Doe",
+  email_address: ["jane@example.com"],
+});
+
+// Update a user
+await clerk.users.update("user_abc123", { first_name: "Janet" });
+
+// Delete a user
+await clerk.users.delete("user_abc123");
+
+// Ban / unban
+await clerk.users.ban("user_abc123");
+await clerk.users.unban("user_abc123");
+
+// Lock / unlock
+await clerk.users.lock("user_abc123");
+await clerk.users.unlock("user_abc123");
+```
+
+## Status
+
+`v0.3.2` — published on npm. APIs may shift before v1.

--- a/packages/clerk-client/eslint.config.js
+++ b/packages/clerk-client/eslint.config.js
@@ -1,0 +1,17 @@
+import { library } from "@theholocron/eslint-config/bundles/library";
+
+/** @type {import("eslint").Linter.Config} */
+const config = [
+	...library(),
+	{
+		rules: {
+			// src/ compiles to dist/ via tsdown; files[] lists dist/ so every
+			// relative src/ import is flagged as unpublished. False positive
+			// for the TypeScript src→dist build model.
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+];
+
+export default config;

--- a/packages/clerk-client/package.json
+++ b/packages/clerk-client/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/clerk-client",
+  "version": "0.3.2",
+  "description": "A TypeScript client for the Clerk Backend API",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/clerk-client#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/clerk-client"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@theholocron/http-client": "^0.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "@theholocron/vitest-config": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/clerk-client/src/__tests__/client.test.ts
+++ b/packages/clerk-client/src/__tests__/client.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createClerkClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "sk_test_abc123";
+
+describe("createClerkClient", () => {
+	it("sends Bearer authorization header", async () => {
+		const { fetch, calls } = stubFetch([{ body: { id: "user_1" } }]);
+		const client = createClerkClient({ token: TOKEN, fetch });
+		await client.users.get("user_1");
+		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+	});
+
+	it("targets the Clerk v1 base URL", async () => {
+		const { fetch, calls } = stubFetch([{ body: { id: "user_1" } }]);
+		const client = createClerkClient({ token: TOKEN, fetch });
+		await client.users.get("user_1");
+		expect(calls[0]?.url).toContain("https://api.clerk.com/v1");
+	});
+});

--- a/packages/clerk-client/src/__tests__/helpers.ts
+++ b/packages/clerk-client/src/__tests__/helpers.ts
@@ -1,0 +1,34 @@
+import { vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export function stubFetch(
+	responses: Array<{ status?: number; body?: unknown; text?: string }>,
+) {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body =
+			typeof init?.body === "string"
+				? JSON.parse(init.body)
+				: (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204) return new Response(null, { status });
+		const text = next.text ?? JSON.stringify(next.body ?? {});
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls };
+}

--- a/packages/clerk-client/src/__tests__/users.test.ts
+++ b/packages/clerk-client/src/__tests__/users.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { createClerkClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "sk_test_abc123";
+
+const mockUser = {
+	id: "user_1",
+	object: "user" as const,
+	external_id: null,
+	primary_email_address_id: "idn_1",
+	primary_phone_number_id: null,
+	primary_web3_wallet_id: null,
+	username: null,
+	first_name: "Test",
+	last_name: "User",
+	profile_image_url: "https://example.com/avatar.jpg",
+	image_url: "https://example.com/avatar.jpg",
+	has_image: false,
+	public_metadata: {},
+	private_metadata: {},
+	unsafe_metadata: {},
+	email_addresses: [],
+	phone_numbers: [],
+	last_sign_in_at: null,
+	banned: false,
+	locked: false,
+	lockout_expires_in_seconds: null,
+	verification_attempts_remaining: null,
+	created_at: 1700000000000,
+	updated_at: 1700000000000,
+	password_enabled: false,
+	two_factor_enabled: false,
+	totp_enabled: false,
+	backup_code_enabled: false,
+};
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const client = createClerkClient({ token: TOKEN, fetch });
+	return { client, calls };
+}
+
+describe("users.list", () => {
+	it("GET /users", async () => {
+		const { client, calls } = makeClient([{ body: [mockUser] }]);
+		await client.users.list();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/users");
+	});
+
+	it("passes limit and offset as query params", async () => {
+		const { client, calls } = makeClient([{ body: [mockUser] }]);
+		await client.users.list({ limit: 10, offset: 20 });
+		expect(calls[0]?.url).toContain("limit=10");
+		expect(calls[0]?.url).toContain("offset=20");
+	});
+
+	it("passes array params as repeated keys", async () => {
+		const { client, calls } = makeClient([{ body: [mockUser] }]);
+		await client.users.list({
+			email_address: ["a@example.com", "b@example.com"],
+		});
+		expect(calls[0]?.url).toContain(
+			"email_address=a%40example.com&email_address=b%40example.com",
+		);
+	});
+});
+
+describe("users.count", () => {
+	it("GET /users/count", async () => {
+		const { client, calls } = makeClient([
+			{ body: { object: "total_count", total_count: 42 } },
+		]);
+		const result = await client.users.count();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/users/count");
+		expect(result.total_count).toBe(42);
+	});
+});
+
+describe("users.get", () => {
+	it("GET /users/:id", async () => {
+		const { client, calls } = makeClient([{ body: mockUser }]);
+		await client.users.get("user_1");
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/users/user_1");
+	});
+});
+
+describe("users.create", () => {
+	it("POST /users", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { ...mockUser, first_name: "New" } },
+		]);
+		await client.users.create({ first_name: "New", last_name: "User" });
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/users");
+		expect(calls[0]?.body).toMatchObject({
+			first_name: "New",
+			last_name: "User",
+		});
+	});
+});
+
+describe("users.update", () => {
+	it("PATCH /users/:id", async () => {
+		const { client, calls } = makeClient([
+			{ body: { ...mockUser, first_name: "Updated" } },
+		]);
+		await client.users.update("user_1", { first_name: "Updated" });
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/users/user_1");
+		expect(calls[0]?.body).toMatchObject({ first_name: "Updated" });
+	});
+});
+
+describe("users.delete", () => {
+	it("DELETE /users/:id returns deleted object", async () => {
+		const { client, calls } = makeClient([
+			{ body: { object: "user", id: "user_1", deleted: true } },
+		]);
+		const result = await client.users.delete("user_1");
+		expect(calls[0]?.method).toBe("DELETE");
+		expect(calls[0]?.url).toContain("/users/user_1");
+		expect(result.deleted).toBe(true);
+	});
+});
+
+describe("users.ban / unban / lock / unlock", () => {
+	it("POST /users/:id/ban", async () => {
+		const { client, calls } = makeClient([
+			{ body: { ...mockUser, banned: true } },
+		]);
+		const result = await client.users.ban("user_1");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/users/user_1/ban");
+		expect(result.banned).toBe(true);
+	});
+
+	it("POST /users/:id/unban", async () => {
+		const { client, calls } = makeClient([{ body: mockUser }]);
+		await client.users.unban("user_1");
+		expect(calls[0]?.url).toContain("/users/user_1/unban");
+	});
+
+	it("POST /users/:id/lock", async () => {
+		const { client, calls } = makeClient([
+			{ body: { ...mockUser, locked: true } },
+		]);
+		const result = await client.users.lock("user_1");
+		expect(calls[0]?.url).toContain("/users/user_1/lock");
+		expect(result.locked).toBe(true);
+	});
+
+	it("POST /users/:id/unlock", async () => {
+		const { client, calls } = makeClient([{ body: mockUser }]);
+		await client.users.unlock("user_1");
+		expect(calls[0]?.url).toContain("/users/user_1/unlock");
+	});
+});

--- a/packages/clerk-client/src/index.ts
+++ b/packages/clerk-client/src/index.ts
@@ -1,0 +1,24 @@
+import { createClerkRestClient, type ClerkClientOptions } from "./utils.js";
+import { users } from "./users/users.js";
+
+export type { ClerkClientOptions } from "./utils.js";
+
+export type {
+	ClerkDeletedObject,
+	ClerkEmailAddress,
+	ClerkPhoneNumber,
+	ClerkUser,
+	ClerkUserCount,
+	ClerkUsersListParams,
+	CreateClerkUserInput,
+	UpdateClerkUserInput,
+} from "./users/users.js";
+
+export function createClerkClient(opts: ClerkClientOptions) {
+	const rest = createClerkRestClient(opts);
+	return {
+		users: users(rest),
+	};
+}
+
+export type ClerkClient = ReturnType<typeof createClerkClient>;

--- a/packages/clerk-client/src/users/users.ts
+++ b/packages/clerk-client/src/users/users.ts
@@ -1,0 +1,193 @@
+import type { RestClient } from "../utils.js";
+
+export interface ClerkEmailAddress {
+	id: string;
+	object: "email_address";
+	email_address: string;
+	verification: { status: string; strategy: string } | null;
+	linked_to: Array<{ id: string; type: string }>;
+	created_at: number;
+	updated_at: number;
+}
+
+export interface ClerkPhoneNumber {
+	id: string;
+	object: "phone_number";
+	phone_number: string;
+	reserved_for_second_factor: boolean;
+	default_second_factor: boolean;
+	verification: { status: string; strategy: string } | null;
+	linked_to: Array<{ id: string; type: string }>;
+	created_at: number;
+	updated_at: number;
+}
+
+export interface ClerkUser {
+	id: string;
+	object: "user";
+	external_id: string | null;
+	primary_email_address_id: string | null;
+	primary_phone_number_id: string | null;
+	primary_web3_wallet_id: string | null;
+	username: string | null;
+	first_name: string | null;
+	last_name: string | null;
+	profile_image_url: string;
+	image_url: string;
+	has_image: boolean;
+	public_metadata: Record<string, unknown>;
+	private_metadata: Record<string, unknown>;
+	unsafe_metadata: Record<string, unknown>;
+	email_addresses: ClerkEmailAddress[];
+	phone_numbers: ClerkPhoneNumber[];
+	last_sign_in_at: number | null;
+	banned: boolean;
+	locked: boolean;
+	lockout_expires_in_seconds: number | null;
+	verification_attempts_remaining: number | null;
+	created_at: number;
+	updated_at: number;
+	password_enabled: boolean;
+	two_factor_enabled: boolean;
+	totp_enabled: boolean;
+	backup_code_enabled: boolean;
+}
+
+export interface ClerkUserCount {
+	object: "total_count";
+	total_count: number;
+}
+
+export interface ClerkDeletedObject {
+	object: string;
+	id: string;
+	slug?: string;
+	deleted: boolean;
+}
+
+export interface ClerkUsersListParams {
+	limit?: number;
+	offset?: number;
+	email_address?: string[];
+	phone_number?: string[];
+	username?: string[];
+	external_id?: string[];
+	user_id?: string[];
+	query?: string;
+	last_active_at_since?: number;
+	order_by?: string;
+}
+
+export interface CreateClerkUserInput {
+	external_id?: string;
+	first_name?: string;
+	last_name?: string;
+	email_address?: string[];
+	phone_number?: string[];
+	web3_wallet?: string[];
+	username?: string;
+	password?: string;
+	password_digest?: string;
+	password_hasher?: string;
+	skip_password_checks?: boolean;
+	skip_password_requirement?: boolean;
+	totp_secret?: string;
+	backup_codes?: string[];
+	public_metadata?: Record<string, unknown>;
+	private_metadata?: Record<string, unknown>;
+	unsafe_metadata?: Record<string, unknown>;
+	created_at?: string;
+}
+
+export interface UpdateClerkUserInput {
+	external_id?: string;
+	first_name?: string;
+	last_name?: string;
+	username?: string;
+	password?: string;
+	primary_email_address_id?: string;
+	notify_primary_email_address_changed?: boolean;
+	primary_phone_number_id?: string;
+	primary_web3_wallet_id?: string;
+	profile_image_id?: string;
+	public_metadata?: Record<string, unknown>;
+	private_metadata?: Record<string, unknown>;
+	unsafe_metadata?: Record<string, unknown>;
+	totp_secret?: string;
+	backup_codes?: string[];
+	delete_self_enabled?: boolean;
+	create_organization_enabled?: boolean;
+}
+
+const PATH = "/users";
+
+function buildUsersQuery(params: ClerkUsersListParams): string {
+	const qs = new URLSearchParams();
+	if (params.limit !== undefined) qs.set("limit", String(params.limit));
+	if (params.offset !== undefined) qs.set("offset", String(params.offset));
+	if (params.query) qs.set("query", params.query);
+	if (params.order_by) qs.set("order_by", params.order_by);
+	if (params.last_active_at_since !== undefined)
+		qs.set("last_active_at_since", String(params.last_active_at_since));
+	for (const v of params.email_address ?? []) qs.append("email_address", v);
+	for (const v of params.phone_number ?? []) qs.append("phone_number", v);
+	for (const v of params.username ?? []) qs.append("username", v);
+	for (const v of params.external_id ?? []) qs.append("external_id", v);
+	for (const v of params.user_id ?? []) qs.append("user_id", v);
+	return qs.toString();
+}
+
+export function users(rest: RestClient) {
+	return {
+		list: (params: ClerkUsersListParams = {}): Promise<ClerkUser[]> => {
+			const q = buildUsersQuery(params);
+			return rest.request<ClerkUser[]>(q ? `${PATH}?${q}` : PATH);
+		},
+
+		count: (
+			params: Pick<
+				ClerkUsersListParams,
+				| "email_address"
+				| "phone_number"
+				| "username"
+				| "external_id"
+				| "user_id"
+				| "query"
+			> = {},
+		): Promise<ClerkUserCount> => {
+			const q = buildUsersQuery(params);
+			return rest.request<ClerkUserCount>(
+				q ? `${PATH}/count?${q}` : `${PATH}/count`,
+			);
+		},
+
+		get: (id: string): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(`${PATH}/${id}`),
+
+		create: (data: CreateClerkUserInput): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(PATH, { method: "POST", body: data }),
+
+		update: (id: string, data: UpdateClerkUserInput): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(`${PATH}/${id}`, {
+				method: "PATCH",
+				body: data,
+			}),
+
+		delete: (id: string): Promise<ClerkDeletedObject> =>
+			rest.request<ClerkDeletedObject>(`${PATH}/${id}`, {
+				method: "DELETE",
+			}),
+
+		ban: (id: string): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(`${PATH}/${id}/ban`, { method: "POST" }),
+
+		unban: (id: string): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(`${PATH}/${id}/unban`, { method: "POST" }),
+
+		lock: (id: string): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(`${PATH}/${id}/lock`, { method: "POST" }),
+
+		unlock: (id: string): Promise<ClerkUser> =>
+			rest.request<ClerkUser>(`${PATH}/${id}/unlock`, { method: "POST" }),
+	};
+}

--- a/packages/clerk-client/src/utils.ts
+++ b/packages/clerk-client/src/utils.ts
@@ -1,0 +1,19 @@
+import { createRestClient, type RestClient } from "@theholocron/http-client";
+
+export type { RestClient };
+
+export interface ClerkClientOptions {
+	/** Clerk secret key (sk_live_... or sk_test_...). */
+	token: string;
+	/** Override fetch for testing. Defaults to globalThis.fetch. */
+	fetch?: typeof fetch;
+}
+
+export function createClerkRestClient(opts: ClerkClientOptions): RestClient {
+	return createRestClient({
+		baseUrl: "https://api.clerk.com/v1",
+		token: opts.token,
+		vendor: "Clerk",
+		fetch: opts.fetch,
+	});
+}

--- a/packages/clerk-client/tsconfig.json
+++ b/packages/clerk-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "display": "Clerk API Client",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "baseUrl": "./", "outDir": "./dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/clerk-client/tsdown.config.ts
+++ b/packages/clerk-client/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/clerk-client/vitest.config.ts
+++ b/packages/clerk-client/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@theholocron/prettier-config':
       specifier: ^6.1.0
       version: 6.1.0
+    '@theholocron/semantic-release-config':
+      specifier: ^6.1.0
+      version: 6.1.0
     '@theholocron/tsconfig':
       specifier: ^6.1.0
       version: 6.1.0
@@ -99,6 +102,9 @@ importers:
       '@theholocron/prettier-config':
         specifier: 'catalog:'
         version: 6.1.0(prettier@3.9.5)
+      '@theholocron/semantic-release-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.7(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 6.1.0(typescript@5.9.3)
@@ -132,6 +138,52 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/clerk-client:
+    dependencies:
+      '@theholocron/http-client':
+        specifier: ^0.3.2
+        version: 0.3.2
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 6.1.0(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.6.1)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/confluence-client:
     dependencies:
@@ -1128,6 +1180,10 @@ packages:
     resolution: {integrity: sha512-C/39cotDB9Wzps72cO0S05y3yZeFHMWYgmHYlbSVNArLJ+Au6+y4r2E/SuMg+PgFzYay8xp/855tnggpfAmf3w==}
     engines: {node: '>=22.0.0'}
 
+  '@theholocron/http-client@0.3.2':
+    resolution: {integrity: sha512-SYrAwP78Akjch0+dxCbkt870ck/OcpJyAgEZw5kfhmb22s1AtMPz6g6YrotzE4ZVyOVTiQpSBQUO/qUpCthHZw==}
+    engines: {node: '>=22.0.0'}
+
   '@theholocron/lint-staged-config@6.1.0':
     resolution: {integrity: sha512-vW9yg6zhDTJiFRQDlWP+ReHDRWXuBsO7iXiR7SYYVhqY8EG/YHg7g4VwqXLBoG+cAe7rUlNKj6GXw5hoqaJ51Q==}
     peerDependencies:
@@ -1145,6 +1201,21 @@ packages:
     resolution: {integrity: sha512-umtOq01lnrE+R+6mHohDIlYCSYPufGCWIXDi+xeJxm28Gx1nLmW7+8jXx4MBo8EanXdDsqtiuXJa7kGCD0638Q==}
     peerDependencies:
       prettier: ^3
+
+  '@theholocron/semantic-release-config@6.1.0':
+    resolution: {integrity: sha512-oUHQxj/mCBno9jQNXcYyIy3qLDmWD1ld9XAjJQZQ1Xr7btCUlLCwbcrCFd30JOyxUd03DhlRbnS7K7HeSM7xbg==}
+    peerDependencies:
+      '@semantic-release/changelog': ^6
+      '@semantic-release/commit-analyzer': ^13
+      '@semantic-release/exec': ^7
+      '@semantic-release/git': ^10
+      '@semantic-release/github': ^11 || ^12
+      '@semantic-release/release-notes-generator': ^14
+      conventional-changelog-conventionalcommits: ^10
+      semantic-release: ^24 || ^25
+    peerDependenciesMeta:
+      '@semantic-release/exec':
+        optional: true
 
   '@theholocron/tsconfig@6.1.0':
     resolution: {integrity: sha512-UFvieJUGqE5GOxfTI1wPXS1MVB8E0q3yzAiJi3viz6CBeNbaZKN5Nu7W5PIF6go1O7wmjCDLF/X/hS35ueJPdA==}
@@ -4314,6 +4385,8 @@ snapshots:
 
   '@theholocron/http-client@0.2.3': {}
 
+  '@theholocron/http-client@0.3.2': {}
+
   '@theholocron/lint-staged-config@6.1.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:
       husky: 9.1.7
@@ -4322,6 +4395,18 @@ snapshots:
   '@theholocron/prettier-config@6.1.0(prettier@3.9.5)':
     dependencies:
       prettier: 3.9.5
+
+  '@theholocron/semantic-release-config@6.1.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.7(typescript@5.9.3))':
+    dependencies:
+      '@semantic-release/changelog': 6.0.3(semantic-release@25.0.7(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.7(typescript@5.9.3))
+      '@semantic-release/git': 10.0.1(semantic-release@25.0.7(typescript@5.9.3))
+      '@semantic-release/github': 12.0.9(semantic-release@25.0.7(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.7(typescript@5.9.3))
+      conventional-changelog-conventionalcommits: 10.2.1
+      semantic-release: 25.0.7(typescript@5.9.3)
+    optionalDependencies:
+      '@semantic-release/exec': 7.1.0(semantic-release@25.0.7(typescript@5.9.3))
 
   '@theholocron/tsconfig@6.1.0(typescript@5.9.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalogs:
 # Shared dep versions used across packages.
 catalog:
   '@theholocron/commitlint-config': ^6.1.0
+  '@theholocron/semantic-release-config': ^6.1.0
   '@theholocron/eslint-config': ^6.1.0
   '@theholocron/lint-staged-config': ^6.1.0
   '@theholocron/prettier-config': ^6.1.0

--- a/release.config.ts
+++ b/release.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "@theholocron/semantic-release-config";
+
+export default defineConfig({
+	exec: {
+		prepareCmd:
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/github-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+		publishCmd:
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
+	},
+});


### PR DESCRIPTION
## Summary

- Adds `@theholocron/clerk-client` — a TypeScript client for the [Clerk Backend API](https://clerk.com/docs/reference/backend-api)
- Implements the `users` resource: `list`, `count`, `get`, `create`, `update`, `delete`, `ban`, `unban`, `lock`, `unlock`
- Registers `packages/clerk-client` in the lockstep `prepareCmd` in both `.releaserc.json` and `release.config.ts`

## Test plan

- [x] `pnpm --filter @theholocron/clerk-client typecheck` — passes
- [x] `pnpm --filter @theholocron/clerk-client lint` — passes
- [x] `pnpm --filter @theholocron/clerk-client test` — 14 tests pass across 2 suites
- [x] `pnpm --filter @theholocron/clerk-client build` — `dist/` emitted (2.19 kB + 4.54 kB types)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->