### PR TITLE
feat(clerk-client): add webhooks and instance resources

### DIFF
--- a/packages/clerk-client/src/__tests__/client.test.ts
+++ b/packages/clerk-client/src/__tests__/client.test.ts
@@ -18,4 +18,15 @@ describe("createClerkClient", () => {
 		await client.users.get("user_1");
 		expect(calls[0]?.url).toContain("https://api.clerk.com/v1");
 	});
+
+	it("respects baseUrl override", async () => {
+		const { fetch, calls } = stubFetch([{ body: { id: "user_1" } }]);
+		const client = createClerkClient({
+			token: TOKEN,
+			baseUrl: "https://clerk.test.invalid/v1",
+			fetch,
+		});
+		await client.users.get("user_1");
+		expect(calls[0]?.url).toContain("https://clerk.test.invalid/v1");
+	});
 });

--- a/packages/clerk-client/src/__tests__/instance.test.ts
+++ b/packages/clerk-client/src/__tests__/instance.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createClerkClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "sk_test_abc123";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const client = createClerkClient({ token: TOKEN, fetch });
+	return { client, calls };
+}
+
+describe("instance.get", () => {
+	it("GET /instance", async () => {
+		const { client, calls } = makeClient([
+			{
+				body: {
+					id: "ins_abc123",
+					object: "instance",
+					environment_type: "development",
+				},
+			},
+		]);
+		const result = await client.instance.get();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/instance");
+		expect(result.id).toBe("ins_abc123");
+		expect(result.environment_type).toBe("development");
+	});
+
+	it("sends Bearer authorization header", async () => {
+		const { client, calls } = makeClient([{ body: { id: "ins_1" } }]);
+		await client.instance.get();
+		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+	});
+});

--- a/packages/clerk-client/src/__tests__/webhooks.test.ts
+++ b/packages/clerk-client/src/__tests__/webhooks.test.ts
@@ -12,7 +12,9 @@ function makeClient(responses: Parameters<typeof stubFetch>[0]) {
 
 describe("webhooks.ensureSvixApp", () => {
 	it("POST /webhooks/svix", async () => {
-		const { client, calls } = makeClient([{ body: { svix_app_id: "app_1" } }]);
+		const { client, calls } = makeClient([
+			{ body: { svix_app_id: "app_1" } },
+		]);
 		const result = await client.webhooks.ensureSvixApp();
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/webhooks/svix");

--- a/packages/clerk-client/src/__tests__/webhooks.test.ts
+++ b/packages/clerk-client/src/__tests__/webhooks.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createClerkClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "sk_test_abc123";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const client = createClerkClient({ token: TOKEN, fetch });
+	return { client, calls };
+}
+
+describe("webhooks.ensureSvixApp", () => {
+	it("POST /webhooks/svix", async () => {
+		const { client, calls } = makeClient([{ body: { svix_app_id: "app_1" } }]);
+		const result = await client.webhooks.ensureSvixApp();
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/webhooks/svix");
+		expect(calls[0]?.url).not.toContain("/webhooks/svix_url");
+		expect(result.svix_app_id).toBe("app_1");
+	});
+
+	it("sends Bearer authorization header", async () => {
+		const { client, calls } = makeClient([{ body: {} }]);
+		await client.webhooks.ensureSvixApp();
+		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+	});
+});
+
+describe("webhooks.getSvixUrl", () => {
+	it("POST /webhooks/svix_url returns url field", async () => {
+		const { client, calls } = makeClient([
+			{ body: { url: "https://app.svix.com/login/abc" } },
+		]);
+		const result = await client.webhooks.getSvixUrl();
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/webhooks/svix_url");
+		expect(result.url).toBe("https://app.svix.com/login/abc");
+	});
+
+	it("surfaces svix_url on older response shape", async () => {
+		const { client } = makeClient([
+			{ body: { svix_url: "https://app.svix.com/login/legacy" } },
+		]);
+		const result = await client.webhooks.getSvixUrl();
+		expect(result.svix_url).toBe("https://app.svix.com/login/legacy");
+	});
+});

--- a/packages/clerk-client/src/index.ts
+++ b/packages/clerk-client/src/index.ts
@@ -1,8 +1,11 @@
 import { createClerkRestClient, type ClerkClientOptions } from "./utils.js";
+import { instance } from "./instance/instance.js";
 import { users } from "./users/users.js";
 import { webhooks } from "./webhooks/webhooks.js";
 
 export type { ClerkClientOptions } from "./utils.js";
+
+export type { ClerkInstance } from "./instance/instance.js";
 
 export type {
 	ClerkDeletedObject,
@@ -20,6 +23,7 @@ export type { ClerkSvixApp, ClerkSvixUrl } from "./webhooks/webhooks.js";
 export function createClerkClient(opts: ClerkClientOptions) {
 	const rest = createClerkRestClient(opts);
 	return {
+		instance: instance(rest),
 		users: users(rest),
 		webhooks: webhooks(rest),
 	};

--- a/packages/clerk-client/src/index.ts
+++ b/packages/clerk-client/src/index.ts
@@ -1,5 +1,6 @@
 import { createClerkRestClient, type ClerkClientOptions } from "./utils.js";
 import { users } from "./users/users.js";
+import { webhooks } from "./webhooks/webhooks.js";
 
 export type { ClerkClientOptions } from "./utils.js";
 
@@ -14,10 +15,13 @@ export type {
 	UpdateClerkUserInput,
 } from "./users/users.js";
 
+export type { ClerkSvixApp, ClerkSvixUrl } from "./webhooks/webhooks.js";
+
 export function createClerkClient(opts: ClerkClientOptions) {
 	const rest = createClerkRestClient(opts);
 	return {
 		users: users(rest),
+		webhooks: webhooks(rest),
 	};
 }
 

--- a/packages/clerk-client/src/instance/instance.ts
+++ b/packages/clerk-client/src/instance/instance.ts
@@ -1,0 +1,13 @@
+import type { RestClient } from "../utils.js";
+
+export interface ClerkInstance {
+	id?: string;
+	object?: string;
+	environment_type?: "development" | "production" | "staging" | string;
+}
+
+export function instance(rest: RestClient) {
+	return {
+		get: (): Promise<ClerkInstance> => rest.request<ClerkInstance>("/instance"),
+	};
+}

--- a/packages/clerk-client/src/instance/instance.ts
+++ b/packages/clerk-client/src/instance/instance.ts
@@ -8,6 +8,7 @@ export interface ClerkInstance {
 
 export function instance(rest: RestClient) {
 	return {
-		get: (): Promise<ClerkInstance> => rest.request<ClerkInstance>("/instance"),
+		get: (): Promise<ClerkInstance> =>
+			rest.request<ClerkInstance>("/instance"),
 	};
 }

--- a/packages/clerk-client/src/utils.ts
+++ b/packages/clerk-client/src/utils.ts
@@ -5,13 +5,15 @@ export type { RestClient };
 export interface ClerkClientOptions {
 	/** Clerk secret key (sk_live_... or sk_test_...). */
 	token: string;
+	/** Override base URL for testing. Defaults to https://api.clerk.com/v1. */
+	baseUrl?: string;
 	/** Override fetch for testing. Defaults to globalThis.fetch. */
 	fetch?: typeof fetch;
 }
 
 export function createClerkRestClient(opts: ClerkClientOptions): RestClient {
 	return createRestClient({
-		baseUrl: "https://api.clerk.com/v1",
+		baseUrl: opts.baseUrl ?? "https://api.clerk.com/v1",
 		token: opts.token,
 		vendor: "Clerk",
 		fetch: opts.fetch,

--- a/packages/clerk-client/src/webhooks/webhooks.ts
+++ b/packages/clerk-client/src/webhooks/webhooks.ts
@@ -1,0 +1,23 @@
+import type { RestClient } from "../utils.js";
+
+export interface ClerkSvixApp {
+	svix_app_id?: string;
+}
+
+/** Older Clerk instances return `svix_url`; newer return `url`. */
+export interface ClerkSvixUrl {
+	url?: string;
+	svix_url?: string;
+}
+
+const PATH = "/webhooks";
+
+export function webhooks(rest: RestClient) {
+	return {
+		ensureSvixApp: (): Promise<ClerkSvixApp> =>
+			rest.request<ClerkSvixApp>(`${PATH}/svix`, { method: "POST" }),
+
+		getSvixUrl: (): Promise<ClerkSvixUrl> =>
+			rest.request<ClerkSvixUrl>(`${PATH}/svix_url`, { method: "POST" }),
+	};
+}


### PR DESCRIPTION
## Summary

Adds two resources needed to migrate `holocron-plugin-clerk` from its inline rest client to the typed `ClerkClient`.

- **`webhooks`** resource: `ensureSvixApp()` (`POST /webhooks/svix`) and `getSvixUrl()` (`POST /webhooks/svix_url`)
- **`instance`** resource: `get()` (`GET /instance`) — used by `verifyToken` to check if a secret key is valid

Exports `ClerkSvixApp`, `ClerkSvixUrl`, and `ClerkInstance` types.

## Test plan

- [x] 6 new tests (4 webhooks + 2 instance)
- [x] typecheck, lint, all 20 tests pass