### PR TITLE
docs: add clerk-client to package table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ API clients and shared HTTP primitives used across the Galaxy.
 | Package                                                          | Description                                                                           |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [`@theholocron/http-client`](./packages/http-client)             | Shared HTTP primitives — `createRestClient`, `createResolveToken`, `ProviderApiError` |
-| [`@theholocron/github-client`](./packages/github-client)         | TypeScript client for the GitHub REST API                                             |
-| [`@theholocron/jira-client`](./packages/jira-client)             | TypeScript client for the Jira REST API                                               |
-| [`@theholocron/google-client`](./packages/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
-| [`@theholocron/zendesk-client`](./packages/zendesk-client)       | TypeScript client for the Zendesk API                                                 |
+| [`@theholocron/clerk-client`](./packages/clerk-client)           | TypeScript client for the Clerk Backend API                                           |
 | [`@theholocron/confluence-client`](./packages/confluence-client) | TypeScript client for the Confluence API                                              |
+| [`@theholocron/github-client`](./packages/github-client)         | TypeScript client for the GitHub REST API                                             |
+| [`@theholocron/google-client`](./packages/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
+| [`@theholocron/jira-client`](./packages/jira-client)             | TypeScript client for the Jira REST API                                               |
+| [`@theholocron/zendesk-client`](./packages/zendesk-client)       | TypeScript client for the Zendesk API                                                 |
 
 ## Development
 


### PR DESCRIPTION
Adds `@theholocron/clerk-client` to the README package table, sorted alphabetically alongside the other clients.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->