### PR TITLE
fix: align http-client dependency versions across all client packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.6.0](https://github.com/theholocron/clients/compare/v0.5.0...v0.6.0) (2026-07-17)
+
 ## [0.5.0](https://github.com/theholocron/clients/compare/v0.4.0...v0.5.0) (2026-07-17)
 
 ## [0.4.0](https://github.com/theholocron/clients/compare/v0.3.2...v0.4.0) (2026-07-16)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ API clients and shared HTTP primitives used across the Galaxy.
 | [`@theholocron/http-client`](./packages/http-client)             | Shared HTTP primitives — `createRestClient`, `createResolveToken`, `ProviderApiError` |
 | [`@theholocron/clerk-client`](./packages/clerk-client)           | TypeScript client for the Clerk Backend API                                           |
 | [`@theholocron/confluence-client`](./packages/confluence-client) | TypeScript client for the Confluence API                                              |
+| [`@theholocron/doppler-client`](./packages/doppler-client)       | TypeScript client for the Doppler API                                                 |
 | [`@theholocron/github-client`](./packages/github-client)         | TypeScript client for the GitHub REST API                                             |
 | [`@theholocron/google-client`](./packages/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
 | [`@theholocron/jira-client`](./packages/jira-client)             | TypeScript client for the Jira REST API                                               |

--- a/packages/clerk-client/package.json
+++ b/packages/clerk-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/clerk-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for the Clerk Backend API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/clerk-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/clerk-client/package.json
+++ b/packages/clerk-client/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "^0.3.2"
+    "@theholocron/http-client": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/confluence-client/package.json
+++ b/packages/confluence-client/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "^0.1.0"
+    "@theholocron/http-client": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/confluence-client/package.json
+++ b/packages/confluence-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/confluence-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for the Confluence API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/confluence-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/doppler-client/README.md
+++ b/packages/doppler-client/README.md
@@ -1,0 +1,45 @@
+# `@theholocron/doppler-client`
+
+TypeScript client for the [Doppler API](https://docs.doppler.com/reference/api).
+
+## Install
+
+```bash
+pnpm add @theholocron/doppler-client
+```
+
+## Usage
+
+```ts
+import { createDopplerClient } from "@theholocron/doppler-client";
+
+const doppler = createDopplerClient({ token: process.env.DOPPLER_TOKEN! });
+
+// Verify token
+const identity = await doppler.me.get();
+
+// List secret names in a config
+const { secrets } = await doppler.secrets.list("my-project", "dev");
+
+// Read a single secret
+const secret = await doppler.secrets.get("my-project", "dev", "DB_URL");
+
+// Write secrets
+await doppler.secrets.update("my-project", "dev", { API_KEY: "new-value" });
+
+// Download all secrets as a flat map
+const env = await doppler.secrets.download("my-project", "dev");
+
+// List environments in a project
+const { environments } = await doppler.environments.list("my-project");
+
+// Create a project
+await doppler.projects.create("my-project", "Managed by holocron");
+
+// Create an environment
+await doppler.environments.create("my-project", "Staging", "stg");
+```
+
+## Status
+
+`v0.5.0` — published on npm. APIs may shift before v1.

--- a/packages/doppler-client/eslint.config.js
+++ b/packages/doppler-client/eslint.config.js
@@ -1,0 +1,14 @@
+import { library } from "@theholocron/eslint-config/bundles/library";
+
+/** @type {import("eslint").Linter.Config} */
+const config = [
+	...library(),
+	{
+		rules: {
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+];
+
+export default config;

--- a/packages/doppler-client/package.json
+++ b/packages/doppler-client/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/doppler-client",
+  "version": "0.5.0",
+  "description": "A TypeScript client for the Doppler API",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/doppler-client#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/doppler-client"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@theholocron/http-client": "^0.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "@theholocron/vitest-config": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/doppler-client/package.json
+++ b/packages/doppler-client/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "^0.5.0"
+    "@theholocron/http-client": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/doppler-client/package.json
+++ b/packages/doppler-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/doppler-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for the Doppler API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/doppler-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/doppler-client/src/__tests__/client.test.ts
+++ b/packages/doppler-client/src/__tests__/client.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createDopplerClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "dp.st.test.abc123";
+
+describe("createDopplerClient", () => {
+	it("sends Bearer authorization header", async () => {
+		const { fetch, calls } = stubFetch([{ body: {} }]);
+		const client = createDopplerClient({ token: TOKEN, fetch });
+		await client.me.get();
+		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+	});
+
+	it("targets the Doppler v3 base URL", async () => {
+		const { fetch, calls } = stubFetch([{ body: {} }]);
+		const client = createDopplerClient({ token: TOKEN, fetch });
+		await client.me.get();
+		expect(calls[0]?.url).toContain("https://api.doppler.com/v3");
+	});
+
+	it("respects baseUrl override", async () => {
+		const { fetch, calls } = stubFetch([{ body: {} }]);
+		const client = createDopplerClient({
+			token: TOKEN,
+			baseUrl: "https://doppler.test.invalid/v3",
+			fetch,
+		});
+		await client.me.get();
+		expect(calls[0]?.url).toContain("https://doppler.test.invalid/v3");
+	});
+});

--- a/packages/doppler-client/src/__tests__/environments.test.ts
+++ b/packages/doppler-client/src/__tests__/environments.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createDopplerClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "dp.st.test.abc123";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	return { client: createDopplerClient({ token: TOKEN, fetch }), calls };
+}
+
+describe("environments.list", () => {
+	it("GET /environments with project param", async () => {
+		const { client, calls } = makeClient([
+			{
+				body: {
+					environments: [
+						{ id: "1", name: "Development", slug: "dev" },
+						{ id: "2", name: "Production", slug: "prd" },
+					],
+				},
+			},
+		]);
+		const result = await client.environments.list("my-project");
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/environments");
+		expect(calls[0]?.url).toContain("project=my-project");
+		expect(result.environments).toHaveLength(2);
+		expect(result.environments?.[0]?.slug).toBe("dev");
+	});
+});
+
+describe("environments.create", () => {
+	it("POST /environments with project, name, slug", async () => {
+		const { client, calls } = makeClient([
+			{ body: { environments: [{ name: "Staging", slug: "stg" }] } },
+		]);
+		await client.environments.create("my-project", "Staging", "stg");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/environments");
+		expect(calls[0]?.body).toMatchObject({
+			project: "my-project",
+			name: "Staging",
+			slug: "stg",
+		});
+	});
+});

--- a/packages/doppler-client/src/__tests__/helpers.ts
+++ b/packages/doppler-client/src/__tests__/helpers.ts
@@ -1,0 +1,34 @@
+import { vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export function stubFetch(
+	responses: Array<{ status?: number; body?: unknown; text?: string }>,
+) {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body =
+			typeof init?.body === "string"
+				? JSON.parse(init.body)
+				: (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204) return new Response(null, { status });
+		const text = next.text ?? JSON.stringify(next.body ?? {});
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls };
+}

--- a/packages/doppler-client/src/__tests__/me.test.ts
+++ b/packages/doppler-client/src/__tests__/me.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createDopplerClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "dp.st.test.abc123";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	return { client: createDopplerClient({ token: TOKEN, fetch }), calls };
+}
+
+describe("me.get", () => {
+	it("GET /me", async () => {
+		const { client, calls } = makeClient([
+			{
+				body: {
+					type: "service",
+					slug: "my-workplace",
+					workplace: { name: "My Workplace", slug: "my-workplace" },
+				},
+			},
+		]);
+		const result = await client.me.get();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/me");
+		expect(result.type).toBe("service");
+		expect(result.workplace?.name).toBe("My Workplace");
+	});
+});

--- a/packages/doppler-client/src/__tests__/projects.test.ts
+++ b/packages/doppler-client/src/__tests__/projects.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { createDopplerClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "dp.st.test.abc123";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	return { client: createDopplerClient({ token: TOKEN, fetch }), calls };
+}
+
+describe("projects.create", () => {
+	it("POST /projects with name", async () => {
+		const { client, calls } = makeClient([
+			{
+				body: {
+					project: {
+						id: "1",
+						name: "my-project",
+						slug: "my-project",
+					},
+				},
+			},
+		]);
+		await client.projects.create("my-project");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/projects");
+		expect(calls[0]?.body).toMatchObject({ name: "my-project" });
+	});
+
+	it("includes description when provided", async () => {
+		const { client, calls } = makeClient([{ body: { project: {} } }]);
+		await client.projects.create("my-project", "Managed by holocron");
+		expect(calls[0]?.body).toMatchObject({
+			name: "my-project",
+			description: "Managed by holocron",
+		});
+	});
+
+	it("omits description when not provided", async () => {
+		const { client, calls } = makeClient([{ body: { project: {} } }]);
+		await client.projects.create("my-project");
+		expect(calls[0]?.body).not.toHaveProperty("description");
+	});
+});

--- a/packages/doppler-client/src/__tests__/secrets.test.ts
+++ b/packages/doppler-client/src/__tests__/secrets.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createDopplerClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "dp.st.test.abc123";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	return { client: createDopplerClient({ token: TOKEN, fetch }), calls };
+}
+
+describe("secrets.get", () => {
+	it("GET /configs/config/secret with project, config, name params", async () => {
+		const { client, calls } = makeClient([
+			{
+				body: {
+					name: "DB_URL",
+					value: {
+						raw: "postgres://...",
+						computed: "postgres://...",
+					},
+				},
+			},
+		]);
+		const result = await client.secrets.get("my-project", "dev", "DB_URL");
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/configs/config/secret");
+		expect(calls[0]?.url).toContain("project=my-project");
+		expect(calls[0]?.url).toContain("config=dev");
+		expect(calls[0]?.url).toContain("name=DB_URL");
+		expect(result.value?.computed).toBe("postgres://...");
+	});
+});
+
+describe("secrets.list", () => {
+	it("GET /configs/config/secrets with project + config params", async () => {
+		const { client, calls } = makeClient([
+			{
+				body: {
+					secrets: {
+						DB_URL: {
+							raw: "postgres://...",
+							computed: "postgres://...",
+						},
+						API_KEY: { raw: "key123", computed: "key123" },
+					},
+				},
+			},
+		]);
+		const result = await client.secrets.list("my-project", "dev");
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/configs/config/secrets");
+		expect(calls[0]?.url).toContain("project=my-project");
+		expect(calls[0]?.url).toContain("config=dev");
+		expect(result.secrets).toHaveProperty("DB_URL");
+		expect(result.secrets).toHaveProperty("API_KEY");
+	});
+});
+
+describe("secrets.update", () => {
+	it("POST /configs/config/secrets with values map", async () => {
+		const { client, calls } = makeClient([{ body: { secrets: {} } }]);
+		await client.secrets.update("my-project", "dev", {
+			NEW_KEY: "new-value",
+		});
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/configs/config/secrets");
+		expect(calls[0]?.body).toMatchObject({
+			project: "my-project",
+			config: "dev",
+			secrets: { NEW_KEY: "new-value" },
+		});
+	});
+});
+
+describe("secrets.download", () => {
+	it("GET /configs/config/secrets/download always uses format=json", async () => {
+		const { client, calls } = makeClient([
+			{ body: { DB_URL: "postgres://...", API_KEY: "key123" } },
+		]);
+		const result = await client.secrets.download("my-project", "dev");
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/configs/config/secrets/download");
+		expect(calls[0]?.url).toContain("format=json");
+		expect(result.DB_URL).toBe("postgres://...");
+	});
+});

--- a/packages/doppler-client/src/environments/environments.ts
+++ b/packages/doppler-client/src/environments/environments.ts
@@ -1,0 +1,30 @@
+import type { RestClient } from "../utils.js";
+
+export interface DopplerEnvironment {
+	id?: string;
+	name?: string;
+	slug?: string;
+}
+
+export interface DopplerEnvironmentsResponse {
+	environments?: DopplerEnvironment[];
+}
+
+export function environments(rest: RestClient) {
+	return {
+		list: (project: string): Promise<DopplerEnvironmentsResponse> =>
+			rest.request<DopplerEnvironmentsResponse>("/environments", {
+				query: { project },
+			}),
+
+		create: (
+			project: string,
+			name: string,
+			slug: string,
+		): Promise<DopplerEnvironmentsResponse> =>
+			rest.request<DopplerEnvironmentsResponse>("/environments", {
+				method: "POST",
+				body: { project, name, slug },
+			}),
+	};
+}

--- a/packages/doppler-client/src/index.ts
+++ b/packages/doppler-client/src/index.ts
@@ -1,0 +1,34 @@
+import { createDopplerRestClient, type DopplerClientOptions } from "./utils.js";
+import { environments } from "./environments/environments.js";
+import { me } from "./me/me.js";
+import { projects } from "./projects/projects.js";
+import { secrets } from "./secrets/secrets.js";
+
+export type { DopplerClientOptions } from "./utils.js";
+
+export type {
+	DopplerEnvironment,
+	DopplerEnvironmentsResponse,
+} from "./environments/environments.js";
+export type { DopplerMe } from "./me/me.js";
+export type {
+	DopplerProject,
+	DopplerProjectResponse,
+} from "./projects/projects.js";
+export type {
+	DopplerSecret,
+	DopplerSecretValue,
+	DopplerSecretsMap,
+} from "./secrets/secrets.js";
+
+export function createDopplerClient(opts: DopplerClientOptions) {
+	const rest = createDopplerRestClient(opts);
+	return {
+		environments: environments(rest),
+		me: me(rest),
+		projects: projects(rest),
+		secrets: secrets(rest),
+	};
+}
+
+export type DopplerClient = ReturnType<typeof createDopplerClient>;

--- a/packages/doppler-client/src/me/me.ts
+++ b/packages/doppler-client/src/me/me.ts
@@ -1,0 +1,18 @@
+import type { RestClient } from "../utils.js";
+
+export interface DopplerMe {
+	/** Token type: "cli" | "personal" | "service" | "service_account". */
+	type?: string;
+	/** Workplace-level identifier. */
+	slug?: string;
+	/** Present on account-level tokens. */
+	workplace?: { name?: string; slug?: string };
+	/** Present on user tokens. */
+	name?: string;
+}
+
+export function me(rest: RestClient) {
+	return {
+		get: (): Promise<DopplerMe> => rest.request<DopplerMe>("/me"),
+	};
+}

--- a/packages/doppler-client/src/projects/projects.ts
+++ b/packages/doppler-client/src/projects/projects.ts
@@ -1,0 +1,25 @@
+import type { RestClient } from "../utils.js";
+
+export interface DopplerProject {
+	id?: string;
+	name?: string;
+	slug?: string;
+	description?: string;
+}
+
+export interface DopplerProjectResponse {
+	project?: DopplerProject;
+}
+
+export function projects(rest: RestClient) {
+	return {
+		create: (
+			name: string,
+			description?: string,
+		): Promise<DopplerProjectResponse> =>
+			rest.request<DopplerProjectResponse>("/projects", {
+				method: "POST",
+				body: { name, ...(description ? { description } : {}) },
+			}),
+	};
+}

--- a/packages/doppler-client/src/secrets/secrets.ts
+++ b/packages/doppler-client/src/secrets/secrets.ts
@@ -1,0 +1,52 @@
+import type { RestClient } from "../utils.js";
+
+export interface DopplerSecretValue {
+	raw?: string;
+	computed?: string;
+}
+
+export interface DopplerSecret {
+	name?: string;
+	value?: DopplerSecretValue | null;
+}
+
+export interface DopplerSecretsMap {
+	secrets?: Record<string, DopplerSecretValue | null>;
+}
+
+export function secrets(rest: RestClient) {
+	return {
+		get: (
+			project: string,
+			config: string,
+			name: string,
+		): Promise<DopplerSecret> =>
+			rest.request<DopplerSecret>("/configs/config/secret", {
+				query: { project, config, name },
+			}),
+
+		list: (project: string, config: string): Promise<DopplerSecretsMap> =>
+			rest.request<DopplerSecretsMap>("/configs/config/secrets", {
+				query: { project, config },
+			}),
+
+		update: (
+			project: string,
+			config: string,
+			values: Record<string, string>,
+		): Promise<DopplerSecretsMap> =>
+			rest.request<DopplerSecretsMap>("/configs/config/secrets", {
+				method: "POST",
+				body: { project, config, secrets: values },
+			}),
+
+		download: (
+			project: string,
+			config: string,
+		): Promise<Record<string, string>> =>
+			rest.request<Record<string, string>>(
+				"/configs/config/secrets/download",
+				{ query: { project, config, format: "json" } },
+			),
+	};
+}

--- a/packages/doppler-client/src/utils.ts
+++ b/packages/doppler-client/src/utils.ts
@@ -1,0 +1,23 @@
+import { createRestClient, type RestClient } from "@theholocron/http-client";
+
+export type { RestClient };
+
+export interface DopplerClientOptions {
+	/** Doppler service token or personal token. */
+	token: string;
+	/** Override base URL for testing. Defaults to https://api.doppler.com/v3. */
+	baseUrl?: string;
+	/** Override fetch for testing. Defaults to globalThis.fetch. */
+	fetch?: typeof fetch;
+}
+
+export function createDopplerRestClient(
+	opts: DopplerClientOptions,
+): RestClient {
+	return createRestClient({
+		baseUrl: opts.baseUrl ?? "https://api.doppler.com/v3",
+		token: opts.token,
+		vendor: "Doppler",
+		fetch: opts.fetch,
+	});
+}

--- a/packages/doppler-client/tsconfig.json
+++ b/packages/doppler-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "display": "Doppler API Client",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "baseUrl": "./", "outDir": "./dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/doppler-client/tsdown.config.ts
+++ b/packages/doppler-client/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/doppler-client/vitest.config.ts
+++ b/packages/doppler-client/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/github-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for the GitHub REST API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/github-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "^0.2.3"
+    "@theholocron/http-client": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/google-client/package.json
+++ b/packages/google-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/google-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for Google Workspace APIs (Docs, Sheets)",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/google-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/http-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared HTTP primitives for theholocron — REST client factory, auth resolver, and error types",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/http-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/jira-client/package.json
+++ b/packages/jira-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/jira-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for the Jira REST API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/jira-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@theholocron/http-client": "^0.1.0"
+    "@theholocron/http-client": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/zendesk-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript client for the Zendesk API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/zendesk-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   packages/clerk-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -188,8 +188,8 @@ importers:
   packages/confluence-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -280,8 +280,8 @@ importers:
   packages/github-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -465,8 +465,8 @@ importers:
   packages/zendesk-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -1221,14 +1221,6 @@ packages:
 
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
-
-  '@theholocron/http-client@0.2.3':
-    resolution: {integrity: sha512-C/39cotDB9Wzps72cO0S05y3yZeFHMWYgmHYlbSVNArLJ+Au6+y4r2E/SuMg+PgFzYay8xp/855tnggpfAmf3w==}
-    engines: {node: '>=22.0.0'}
-
-  '@theholocron/http-client@0.3.2':
-    resolution: {integrity: sha512-SYrAwP78Akjch0+dxCbkt870ck/OcpJyAgEZw5kfhmb22s1AtMPz6g6YrotzE4ZVyOVTiQpSBQUO/qUpCthHZw==}
-    engines: {node: '>=22.0.0'}
 
   '@theholocron/http-client@0.5.0':
     resolution: {integrity: sha512-W1JO8JCsAXf/koPzxAPAZqdG1rkXrsEfW/TpRL0vW9lFYrbsUWkyEH850bR5wOiYUL2J0ZgjEB18rRn4BAPhPA==}
@@ -4432,10 +4424,6 @@ snapshots:
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@0.1.0': {}
-
-  '@theholocron/http-client@0.2.3': {}
-
-  '@theholocron/http-client@0.3.2': {}
 
   '@theholocron/http-client@0.5.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   packages/clerk-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -188,8 +188,8 @@ importers:
   packages/confluence-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -234,8 +234,8 @@ importers:
   packages/doppler-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -280,8 +280,8 @@ importers:
   packages/github-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -465,8 +465,8 @@ importers:
   packages/zendesk-client:
     dependencies:
       '@theholocron/http-client':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
@@ -1222,8 +1222,8 @@ packages:
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
 
-  '@theholocron/http-client@0.5.0':
-    resolution: {integrity: sha512-W1JO8JCsAXf/koPzxAPAZqdG1rkXrsEfW/TpRL0vW9lFYrbsUWkyEH850bR5wOiYUL2J0ZgjEB18rRn4BAPhPA==}
+  '@theholocron/http-client@0.6.0':
+    resolution: {integrity: sha512-e3Y42FmikXGuP1Par2oNT1tJfiA13Qg1Ek8TK3xjWu2hReJOUr+PrNw+yDjJkJfDu0G+ihGdHuQzIydlq8ro0Q==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@6.1.0':
@@ -4425,7 +4425,7 @@ snapshots:
 
   '@theholocron/http-client@0.1.0': {}
 
-  '@theholocron/http-client@0.5.0': {}
+  '@theholocron/http-client@0.6.0': {}
 
   '@theholocron/lint-staged-config@6.1.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,52 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/doppler-client:
+    dependencies:
+      '@theholocron/http-client':
+        specifier: ^0.5.0
+        version: 0.5.0
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 6.1.0(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: 'catalog:'
+        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.6.1)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/github-client:
     dependencies:
       '@theholocron/http-client':
@@ -1182,6 +1228,10 @@ packages:
 
   '@theholocron/http-client@0.3.2':
     resolution: {integrity: sha512-SYrAwP78Akjch0+dxCbkt870ck/OcpJyAgEZw5kfhmb22s1AtMPz6g6YrotzE4ZVyOVTiQpSBQUO/qUpCthHZw==}
+    engines: {node: '>=22.0.0'}
+
+  '@theholocron/http-client@0.5.0':
+    resolution: {integrity: sha512-W1JO8JCsAXf/koPzxAPAZqdG1rkXrsEfW/TpRL0vW9lFYrbsUWkyEH850bR5wOiYUL2J0ZgjEB18rRn4BAPhPA==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@6.1.0':
@@ -4386,6 +4436,8 @@ snapshots:
   '@theholocron/http-client@0.2.3': {}
 
   '@theholocron/http-client@0.3.2': {}
+
+  '@theholocron/http-client@0.5.0': {}
 
   '@theholocron/lint-staged-config@6.1.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:

--- a/release.config.ts
+++ b/release.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/github-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/doppler-client','packages/github-client','packages/google-client','packages/http-client','packages/jira-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
## Summary

- Updates `@theholocron/http-client` dependency to `^0.5.0` in every client package that had a stale range (`^0.1.0`, `^0.2.3`, `^0.3.2`)
- Adds `@theholocron/doppler-client` to the README package table
- Packages affected: `clerk-client`, `confluence-client`, `github-client`, `zendesk-client` (doppler-client was already correct)

Triggering this `fix:` release also ensures the CI build step runs before publish, which will produce the `dist/` output that was missing from the `doppler-client@0.5.0` initial manual publish.

## Test plan

- [x] `pnpm install` resolves cleanly against npm registry
- [x] All client packages now have `@theholocron/http-client: "^0.5.0"` (consistent across all)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->