### PR TITLE
fix(doppler-client): use strict undefined check for optional description param

### DIFF
--- a/packages/doppler-client/src/projects/projects.ts
+++ b/packages/doppler-client/src/projects/projects.ts
@@ -19,7 +19,7 @@ export function projects(rest: RestClient) {
 		): Promise<DopplerProjectResponse> =>
 			rest.request<DopplerProjectResponse>("/projects", {
 				method: "POST",
-				body: { name, ...(description ? { description } : {}) },
+				body: { name, ...(description !== undefined ? { description } : {}) },
 			}),
 	};
 }

--- a/packages/doppler-client/src/projects/projects.ts
+++ b/packages/doppler-client/src/projects/projects.ts
@@ -19,7 +19,10 @@ export function projects(rest: RestClient) {
 		): Promise<DopplerProjectResponse> =>
 			rest.request<DopplerProjectResponse>("/projects", {
 				method: "POST",
-				body: { name, ...(description !== undefined ? { description } : {}) },
+				body: {
+					name,
+					...(description !== undefined ? { description } : {}),
+				},
 			}),
 	};
 }


### PR DESCRIPTION
## Summary

`projects.create` used a truthy check on the optional `description` parameter — an empty string `""` would be silently excluded from the request body. Changed to `!== undefined` to match the parameter type and pass empty strings through.

Also triggers a new patch release so all packages publish cleanly via CI with proper `dist/` output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->