### PR TITLE
chore: publish missing 0.6.1 packages

### DIFF
--- a/.github/workflows/publish-missing.yml
+++ b/.github/workflows/publish-missing.yml
@@ -1,0 +1,30 @@
+name: Publish missing packages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter @theholocron/http-client --filter @theholocron/jira-client --filter @theholocron/zendesk-client build
+
+      - run: pnpm --filter @theholocron/http-client --filter @theholocron/jira-client --filter @theholocron/zendesk-client publish --access public --no-git-checks --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/publish-missing.yml
+++ b/.github/workflows/publish-missing.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .node-version
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: pnpm
 


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow to publish `http-client`, `jira-client`, and `zendesk-client` at 0.6.1 — these were skipped in the 0.6.1 release run due to OIDC not being configured at the time. Merge this, then trigger the workflow from the Actions tab. Delete the workflow in a follow-up once all packages are at 0.6.1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->