### PR TITLE
fix: use NPM_TOKEN instead of OIDC in publish-missing workflow

### DIFF
--- a/.github/workflows/publish-missing.yml
+++ b/.github/workflows/publish-missing.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
+  contents: read
 
 jobs:
   publish:
@@ -27,4 +27,3 @@ jobs:
       - run: pnpm --filter @theholocron/http-client --filter @theholocron/jira-client --filter @theholocron/zendesk-client publish --access public --no-git-checks --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
The `publish-missing.yml` workflow's OIDC token is rejected by npm Trusted Publishing because the `job_workflow_ref` claim doesn't match the allowed workflow (`release.yml`). Switches to `NPM_TOKEN` (automation token) which bypasses that restriction. Requires `NPM_TOKEN` to be set as a repository secret.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->