### PR TITLE
chore(deps): bump @theholocron/* config packages to ^7.0.0

### DIFF
--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -420,5 +420,25 @@ No additional `overrides:` entry is needed — the existing
 ## 10. First publish
 
 New packages need a one-time manual publish before OIDC Trusted Publishing
-takes over. See the root `README.md` for the `holocron npm publish-initial`
-workflow.
+takes over. After the PR merges and the lockstep release runs, the new
+package will be skipped by OIDC (it doesn't exist on npm yet). Publish it
+manually from the clients repo root:
+
+```sh
+npm login --auth-type=web
+pnpm exec holocron npm publish-initial --tag latest --otp <6-digit-code>
+```
+
+`--otp` is required if your npm account has 2FA for writes enabled.
+`--tag latest` overrides the command's default of `alpha`.
+
+The command publishes all workspace packages — packages that already exist
+on npm will be skipped harmlessly. Once complete, set up OIDC Trusted
+Publishing for the new package so future lockstep releases work
+automatically:
+
+```
+https://www.npmjs.com/package/@theholocron/<slug>-client/access
+```
+
+Publisher settings: **GitHub Actions · org: theholocron · repo: clients · workflow: release.yml**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,29 +7,29 @@ settings:
 catalogs:
   default:
     '@theholocron/commitlint-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/eslint-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/lint-staged-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/prettier-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/semantic-release-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/tsconfig':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/tsdown-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@theholocron/vitest-config':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     '@vitest/coverage-v8':
       specifier: ^4.1.10
       version: 4.1.10
@@ -92,25 +92,25 @@ importers:
         version: 2.0.0-alpha.36
       '@theholocron/commitlint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
+        version: 7.0.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
         version: 2.0.0-alpha.36(@theholocron/cli@2.0.0-alpha.36)
       '@theholocron/lint-staged-config':
         specifier: 'catalog:'
-        version: 6.1.0(husky@9.1.7)(lint-staged@16.4.0)
+        version: 7.0.0(husky@9.1.7)(lint-staged@16.4.0)
       '@theholocron/prettier-config':
         specifier: 'catalog:'
-        version: 6.1.0(prettier@3.9.5)
+        version: 7.0.0(prettier@3.9.5)
       '@theholocron/semantic-release-config':
         specifier: 'catalog:'
-        version: 6.1.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.7(typescript@5.9.3))
+        version: 7.0.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.7(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       alexjs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -150,16 +150,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -196,16 +196,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -242,16 +242,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -288,16 +288,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -343,16 +343,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/server-destroy':
         specifier: ^1.0.4
         version: 1.0.4
@@ -385,16 +385,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -431,16 +431,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -473,16 +473,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -519,16 +519,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -565,16 +565,16 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 6.1.0(typescript@5.9.3)
+        version: 7.0.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -1276,14 +1276,14 @@ packages:
     resolution: {integrity: sha512-up/NEAKdbhnYGdJ4m8w4BT4ou7qjSFeJJHXaXBD5Mcj2uxeARVHSc5VsgSQRZXZRMyzkRs0Dd2Uqa2O0iEblwQ==}
     hasBin: true
 
-  '@theholocron/commitlint-config@6.1.0':
-    resolution: {integrity: sha512-dkJg0U1KVZBPRH+eDgTTewUqUbMT94jxV9XikqfkF5RdNEb3k/Bc8ijWkJt968MkDcdRu4vJqPq35NDHui97Dw==}
+  '@theholocron/commitlint-config@7.0.0':
+    resolution: {integrity: sha512-8hOkQ6k1cUbReyi56CL2z7RCwBJ7gYA011rY+RRXHm/c/EvNIKcIdCFWmncmhATBiafQdqv1AqhZIDPSm3pR/g==}
     peerDependencies:
-      '@commitlint/cli': ^19
+      '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^19.8.1
 
-  '@theholocron/eslint-config@6.1.0':
-    resolution: {integrity: sha512-GV4UBvTvx74N0D1hCw/M9myn0LR2vGDqMXq2KxMtsUozmjdS+w0wzhWKvQ8WoNH8+XX360inA+s6fvLkW0NJzA==}
+  '@theholocron/eslint-config@7.0.0':
+    resolution: {integrity: sha512-c5siaN8gwRTDHZJcTELMD4XMON4KFbrynMPTZsuvwqHksKgAdyRC2PqzzPJVvUWrcnqRqmIg5z44HVFk254z6A==}
     peerDependencies:
       '@eslint/js': ^10
       '@next/eslint-plugin-next': ^16
@@ -1325,8 +1325,8 @@ packages:
     resolution: {integrity: sha512-D2zC97WwBtMSrfKFtZM3GPVHxbuTJeMDjBH/JxlcB5YYSUzWX+LXrN8GrcHgm9heOPcwEf2GOGN6K9+DBq8Ntg==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/lint-staged-config@6.1.0':
-    resolution: {integrity: sha512-vW9yg6zhDTJiFRQDlWP+ReHDRWXuBsO7iXiR7SYYVhqY8EG/YHg7g4VwqXLBoG+cAe7rUlNKj6GXw5hoqaJ51Q==}
+  '@theholocron/lint-staged-config@7.0.0':
+    resolution: {integrity: sha512-7KbmYo3czPfit3UE94OJH9kg5NPWYLY3iugm58swxxnBX5wIvKNIcyH007vjJ4M7zil030dqmASx1pT97dNg2g==}
     peerDependencies:
       husky: ^9
       imagemin-lint-staged: ^0.5
@@ -1338,13 +1338,13 @@ packages:
       sort-package-json:
         optional: true
 
-  '@theholocron/prettier-config@6.1.0':
-    resolution: {integrity: sha512-umtOq01lnrE+R+6mHohDIlYCSYPufGCWIXDi+xeJxm28Gx1nLmW7+8jXx4MBo8EanXdDsqtiuXJa7kGCD0638Q==}
+  '@theholocron/prettier-config@7.0.0':
+    resolution: {integrity: sha512-LiZ5GCV9QDTeRq8Rw+sV8r/j9W/w1OFCoO7SJWU+UujnhAge1/9Ka+ShsBcecpvZsj6VItJKwPA4vpc+dRYT/Q==}
     peerDependencies:
       prettier: ^3
 
-  '@theholocron/semantic-release-config@6.1.0':
-    resolution: {integrity: sha512-oUHQxj/mCBno9jQNXcYyIy3qLDmWD1ld9XAjJQZQ1Xr7btCUlLCwbcrCFd30JOyxUd03DhlRbnS7K7HeSM7xbg==}
+  '@theholocron/semantic-release-config@7.0.0':
+    resolution: {integrity: sha512-fXjNmO/TM09tUBM6X4TGZSz4j4iBkRFRSDS7OnMO4kL2c7JyF1vJdx6LkGaWKifmprdBHVVhEEppkLgtpo02Og==}
     peerDependencies:
       '@semantic-release/changelog': ^6
       '@semantic-release/commit-analyzer': ^13
@@ -1358,18 +1358,18 @@ packages:
       '@semantic-release/exec':
         optional: true
 
-  '@theholocron/tsconfig@6.1.0':
-    resolution: {integrity: sha512-UFvieJUGqE5GOxfTI1wPXS1MVB8E0q3yzAiJi3viz6CBeNbaZKN5Nu7W5PIF6go1O7wmjCDLF/X/hS35ueJPdA==}
+  '@theholocron/tsconfig@7.0.0':
+    resolution: {integrity: sha512-qswP8dhQVtfZpMViWj0XS4Ew54vcS4RsOXH24kOVXQ/R+YXojqQdAO6hIJ3s41hxG0QwfHRQw0KMZtei30PmwQ==}
     peerDependencies:
       typescript: ^5
 
-  '@theholocron/tsdown-config@6.1.0':
-    resolution: {integrity: sha512-FKuJqYNOvk9L6N/QxNVJDAiktggZ4R4JW3HbecyObEvXBFMRkA7AfhuADFh5PIjCj0ls6Uu+eSiQNTvWsali5A==}
+  '@theholocron/tsdown-config@7.0.0':
+    resolution: {integrity: sha512-e8j9VJHNM9aeGPmhwuXODAodrjtrpcdNYnsbFw/mJDCTMWryRFai0dt4HHE8DHgQJ/PRe5xJw/2mxYmq/feLIw==}
     peerDependencies:
       tsdown: ^0
 
-  '@theholocron/vitest-config@6.1.0':
-    resolution: {integrity: sha512-DdYjB8lNLX0fjinBOK9ty5mV1TpuYpAotHvLCDTmQeEUZocWP4LObilQ8obqU/ZuGXZ/B01ThaUryX2njFPaVQ==}
+  '@theholocron/vitest-config@7.0.0':
+    resolution: {integrity: sha512-McB30D7WyMTd5+cJZMnFZLwDNhE+KTPrjGigzwLu51uix3aSJOlGoU6Ep2951/7EirJdHQLAMpxo/8QIO7zsQg==}
     peerDependencies:
       '@storybook/addon-vitest': ^9
       '@testing-library/react': ^16
@@ -4502,12 +4502,12 @@ snapshots:
       tsx: 4.23.1
       yargs: 18.0.0
 
-  '@theholocron/commitlint-config@6.1.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
+  '@theholocron/commitlint-config@7.0.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:
       '@commitlint/cli': 19.8.1(@types/node@26.1.1)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
 
-  '@theholocron/eslint-config@6.1.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.7.0(jiti@2.6.1))
       eslint: 10.7.0(jiti@2.6.1)
@@ -4528,16 +4528,16 @@ snapshots:
 
   '@theholocron/http-client@0.7.0': {}
 
-  '@theholocron/lint-staged-config@6.1.0(husky@9.1.7)(lint-staged@16.4.0)':
+  '@theholocron/lint-staged-config@7.0.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:
       husky: 9.1.7
       lint-staged: 16.4.0
 
-  '@theholocron/prettier-config@6.1.0(prettier@3.9.5)':
+  '@theholocron/prettier-config@7.0.0(prettier@3.9.5)':
     dependencies:
       prettier: 3.9.5
 
-  '@theholocron/semantic-release-config@6.1.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.7(typescript@5.9.3))':
+  '@theholocron/semantic-release-config@7.0.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.7(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.7(typescript@5.9.3))':
     dependencies:
       '@semantic-release/changelog': 6.0.3(semantic-release@25.0.7(typescript@5.9.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.7(typescript@5.9.3))
@@ -4549,15 +4549,15 @@ snapshots:
     optionalDependencies:
       '@semantic-release/exec': 7.1.0(semantic-release@25.0.7(typescript@5.9.3))
 
-  '@theholocron/tsconfig@6.1.0(typescript@5.9.3)':
+  '@theholocron/tsconfig@7.0.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@theholocron/tsdown-config@6.1.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))':
+  '@theholocron/tsdown-config@7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))':
     dependencies:
       tsdown: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
 
-  '@theholocron/vitest-config@6.1.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+  '@theholocron/vitest-config@7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,14 +9,14 @@ catalogs:
 
 # Shared dep versions used across packages.
 catalog:
-  '@theholocron/commitlint-config': ^6.1.0
-  '@theholocron/semantic-release-config': ^6.1.0
-  '@theholocron/eslint-config': ^6.1.0
-  '@theholocron/lint-staged-config': ^6.1.0
-  '@theholocron/prettier-config': ^6.1.0
-  '@theholocron/tsconfig': ^6.1.0
-  '@theholocron/tsdown-config': ^6.1.0
-  '@theholocron/vitest-config': ^6.1.0
+  '@theholocron/commitlint-config': ^7.0.0
+  '@theholocron/semantic-release-config': ^7.0.0
+  '@theholocron/eslint-config': ^7.0.0
+  '@theholocron/lint-staged-config': ^7.0.0
+  '@theholocron/prettier-config': ^7.0.0
+  '@theholocron/tsconfig': ^7.0.0
+  '@theholocron/tsdown-config': ^7.0.0
+  '@theholocron/vitest-config': ^7.0.0
   '@vitest/eslint-plugin': ^1.6.23
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2


### PR DESCRIPTION
## Summary

Bump all `@theholocron/*` config packages from `^6.1.0` → `^7.0.0` in the pnpm catalog.

v7.0.0 is a breaking change in `theholocron/configs` ([PR #242](https://github.com/theholocron/configs/pull/242)) that converts all config packages from plain JS source-as-artifact to TypeScript compiled to `dist/` via tsdown. Consumers gain:
- Proper `.d.ts` type declarations shipped alongside JS — type inference flows through without manual JSDoc or `satisfies` annotations
- No change to import paths or runtime behavior

## Blocked on

**theholocron/configs#242** must merge and publish before `pnpm install` can resolve `^7.0.0`. Merge this PR immediately after the configs release lands.

## Test plan

- [ ] configs#242 is merged and `7.0.0` is published to npm
- [ ] `pnpm install` resolves cleanly
- [ ] `pnpm lint && pnpm test && pnpm build` pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->