### PR TITLE
feat: add @theholocron/postman-client

### DIFF
--- a/packages/postman-client/README.md
+++ b/packages/postman-client/README.md
@@ -28,16 +28,25 @@ const { collections } = await postman.collections.list("workspace-id");
 await postman.collections.delete("collection-uid");
 
 // Import an OpenAPI spec as a collection
-const { collections: imported } = await postman.import.openapi("workspace-id", spec);
+const { collections: imported } = await postman.import.openapi(
+  "workspace-id",
+  spec,
+);
 
 // List environments
 const { environments } = await postman.environments.list("workspace-id");
 
 // Create an environment
-await postman.environments.create("workspace-id", { name: "Production", values: [] });
+await postman.environments.create("workspace-id", {
+  name: "Production",
+  values: [],
+});
 
 // Update an environment
-await postman.environments.update("environment-uid", { name: "Production", values: [] });
+await postman.environments.update("environment-uid", {
+  name: "Production",
+  values: [],
+});
 
 // List Spec Hub specs
 const { specs } = await postman.specs.list("workspace-id");
@@ -49,7 +58,11 @@ await postman.specs.create("workspace-id", {
 });
 
 // Update a spec file
-await postman.specs.updateFile("spec-id", "index.json", JSON.stringify(updatedSpec));
+await postman.specs.updateFile(
+  "spec-id",
+  "index.json",
+  JSON.stringify(updatedSpec),
+);
 ```
 
 ## Status

--- a/packages/postman-client/README.md
+++ b/packages/postman-client/README.md
@@ -1,0 +1,57 @@
+# `@theholocron/postman-client`
+
+TypeScript client for the [Postman API](https://www.postman.com/postman/postman-public-workspace/documentation/8kv5pif/postman-api).
+
+## Install
+
+```bash
+pnpm add @theholocron/postman-client
+```
+
+## Usage
+
+```ts
+import { createPostmanClient } from "@theholocron/postman-client";
+
+const postman = createPostmanClient({ token: process.env.POSTMAN_API_KEY! });
+
+// Get the authenticated user
+const { user } = await postman.me.get();
+
+// List workspaces
+const { workspaces } = await postman.workspaces.list();
+
+// List collections in a workspace
+const { collections } = await postman.collections.list("workspace-id");
+
+// Delete a collection
+await postman.collections.delete("collection-uid");
+
+// Import an OpenAPI spec as a collection
+const { collections: imported } = await postman.import.openapi("workspace-id", spec);
+
+// List environments
+const { environments } = await postman.environments.list("workspace-id");
+
+// Create an environment
+await postman.environments.create("workspace-id", { name: "Production", values: [] });
+
+// Update an environment
+await postman.environments.update("environment-uid", { name: "Production", values: [] });
+
+// List Spec Hub specs
+const { specs } = await postman.specs.list("workspace-id");
+
+// Create a spec
+await postman.specs.create("workspace-id", {
+  name: "My API",
+  fileContent: JSON.stringify(openApiSpec),
+});
+
+// Update a spec file
+await postman.specs.updateFile("spec-id", "index.json", JSON.stringify(updatedSpec));
+```
+
+## Status
+
+`v0.8.0` — published on npm. APIs may shift before v1.

--- a/packages/postman-client/eslint.config.ts
+++ b/packages/postman-client/eslint.config.ts
@@ -1,0 +1,14 @@
+import type { Linter } from "eslint";
+import { library } from "@theholocron/eslint-config/bundles/library";
+
+const config = [
+	...library(),
+	{
+		rules: {
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+] satisfies Linter.Config[];
+
+export default config;

--- a/packages/postman-client/package.json
+++ b/packages/postman-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/postman-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A TypeScript client for the Postman API",
   "homepage": "https://github.com/theholocron/clients/tree/main/packages/postman-client#readme",
   "bugs": "https://github.com/theholocron/clients/issues",

--- a/packages/postman-client/package.json
+++ b/packages/postman-client/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/postman-client",
+  "version": "0.8.0",
+  "description": "A TypeScript client for the Postman API",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/postman-client#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/postman-client"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@theholocron/http-client": "^0.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "@theholocron/vitest-config": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/postman-client/src/__tests__/client.test.ts
+++ b/packages/postman-client/src/__tests__/client.test.ts
@@ -32,10 +32,17 @@ describe("createPostmanClient", () => {
 	});
 
 	it("wraps limitReachedError as PostmanPlanLimitError", async () => {
-		const { fetch } = stubFetch([{
-			status: 403,
-			text: JSON.stringify({ error: { name: "limitReachedError", message: "upgrade required" } }),
-		}]);
+		const { fetch } = stubFetch([
+			{
+				status: 403,
+				text: JSON.stringify({
+					error: {
+						name: "limitReachedError",
+						message: "upgrade required",
+					},
+				}),
+			},
+		]);
 		const client = createPostmanClient({ token: TOKEN, fetch });
 		const err = await client.specs.list("ws1").catch((e: unknown) => e);
 		expect((err as Error).name).toBe("PostmanPlanLimitError");

--- a/packages/postman-client/src/__tests__/client.test.ts
+++ b/packages/postman-client/src/__tests__/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createPostmanClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "postman-test-key";
+
+describe("createPostmanClient", () => {
+	it("sends x-api-key header (not Authorization)", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createPostmanClient({ token: TOKEN, fetch });
+		await client.me.get();
+		expect(calls[0]?.headers["x-api-key"]).toBe(TOKEN);
+		expect(calls[0]?.headers.authorization).toBeUndefined();
+	});
+
+	it("targets the Postman base URL", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createPostmanClient({ token: TOKEN, fetch });
+		await client.me.get();
+		expect(calls[0]?.url).toContain("https://api.getpostman.com");
+	});
+
+	it("respects baseUrl override", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createPostmanClient({
+			token: TOKEN,
+			baseUrl: "https://postman.test.invalid",
+			fetch,
+		});
+		await client.me.get();
+		expect(calls[0]?.url).toContain("https://postman.test.invalid");
+	});
+
+	it("wraps limitReachedError as PostmanPlanLimitError", async () => {
+		const { fetch } = stubFetch([{
+			status: 403,
+			text: JSON.stringify({ error: { name: "limitReachedError", message: "upgrade required" } }),
+		}]);
+		const client = createPostmanClient({ token: TOKEN, fetch });
+		const err = await client.specs.list("ws1").catch((e: unknown) => e);
+		expect((err as Error).name).toBe("PostmanPlanLimitError");
+		expect((err as Error).message).toBe("upgrade required");
+	});
+});

--- a/packages/postman-client/src/__tests__/helpers.ts
+++ b/packages/postman-client/src/__tests__/helpers.ts
@@ -1,0 +1,34 @@
+import { vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export function stubFetch(
+	responses: Array<{ status?: number; body?: unknown; text?: string }>,
+) {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body =
+			typeof init?.body === "string"
+				? JSON.parse(init.body)
+				: (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204) return new Response(null, { status });
+		const text = next.text ?? JSON.stringify(next.body ?? {});
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls };
+}

--- a/packages/postman-client/src/__tests__/resources.test.ts
+++ b/packages/postman-client/src/__tests__/resources.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { createPostmanClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "postman-test-key";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	return { client: createPostmanClient({ token: TOKEN, fetch }), calls };
+}
+
+describe("me.get", () => {
+	it("GET /me", async () => {
+		const { client, calls } = makeClient([
+			{ body: { user: { id: 1, username: "newton", email: "n@example.com" } } },
+		]);
+		const result = await client.me.get();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/me");
+		expect(result.user?.username).toBe("newton");
+	});
+});
+
+describe("workspaces.list", () => {
+	it("GET /workspaces", async () => {
+		const { client, calls } = makeClient([
+			{ body: { workspaces: [{ id: "ws1", name: "My Workspace", type: "personal" }] } },
+		]);
+		const result = await client.workspaces.list();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/workspaces");
+		expect(result.workspaces[0]?.name).toBe("My Workspace");
+	});
+});
+
+describe("collections.list", () => {
+	it("GET /collections?workspace={id}", async () => {
+		const { client, calls } = makeClient([
+			{ body: { collections: [{ id: "c1", uid: "c1-uid", name: "My API" }] } },
+		]);
+		const result = await client.collections.list("ws1");
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/collections");
+		expect(calls[0]?.url).toContain("workspace=ws1");
+		expect(result.collections[0]?.name).toBe("My API");
+	});
+});
+
+describe("collections.delete", () => {
+	it("DELETE /collections/{uid}", async () => {
+		const { client, calls } = makeClient([{ status: 200, body: {} }]);
+		await client.collections.delete("c1-uid");
+		expect(calls[0]?.method).toBe("DELETE");
+		expect(calls[0]?.url).toContain("/collections/c1-uid");
+	});
+});
+
+describe("environments.list", () => {
+	it("GET /environments?workspace={id}", async () => {
+		const { client, calls } = makeClient([
+			{ body: { environments: [{ id: "e1", uid: "e1-uid", name: "Production" }] } },
+		]);
+		const result = await client.environments.list("ws1");
+		expect(calls[0]?.url).toContain("/environments");
+		expect(calls[0]?.url).toContain("workspace=ws1");
+		expect(result.environments[0]?.name).toBe("Production");
+	});
+});
+
+describe("environments.create", () => {
+	it("POST /environments?workspace={id}", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { environment: { id: "e2", uid: "e2-uid", name: "Staging" } } },
+		]);
+		const env = { name: "Staging", values: [] };
+		await client.environments.create("ws1", env);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/environments");
+		expect(calls[0]?.url).toContain("workspace=ws1");
+		expect(calls[0]?.body).toMatchObject({ environment: env });
+	});
+});
+
+describe("environments.update", () => {
+	it("PUT /environments/{uid}", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { environment: { id: "e1", uid: "e1-uid", name: "Production" } } },
+		]);
+		const env = { name: "Production", values: [{ key: "URL", value: "https://prod" }] };
+		await client.environments.update("e1-uid", env);
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain("/environments/e1-uid");
+		expect(calls[0]?.body).toMatchObject({ environment: env });
+	});
+});
+
+describe("specs.list", () => {
+	it("GET /specs?workspaceId={id}", async () => {
+		const { client, calls } = makeClient([
+			{ body: { specs: [{ id: "s1", name: "My API Spec", type: "OPENAPI:3.0" }] } },
+		]);
+		const result = await client.specs.list("ws1");
+		expect(calls[0]?.url).toContain("/specs");
+		expect(calls[0]?.url).toContain("workspaceId=ws1");
+		expect(result.specs[0]?.name).toBe("My API Spec");
+	});
+});
+
+describe("specs.create", () => {
+	it("POST /specs?workspaceId={id} with name + files", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { id: "s2", name: "New Spec", type: "OPENAPI:3.0" } },
+		]);
+		await client.specs.create("ws1", { name: "New Spec", fileContent: '{"openapi":"3.0"}' });
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/specs");
+		expect(calls[0]?.url).toContain("workspaceId=ws1");
+		expect(calls[0]?.body).toMatchObject({
+			name: "New Spec",
+			type: "OPENAPI:3.0",
+			files: [{ path: "index.json", content: '{"openapi":"3.0"}' }],
+		});
+	});
+});
+
+describe("specs.updateFile", () => {
+	it("PATCH /specs/{specId}/files/{filePath}", async () => {
+		const { client, calls } = makeClient([{ status: 200, body: {} }]);
+		await client.specs.updateFile("s1", "index.json", '{"openapi":"3.1"}');
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/specs/s1/files/index.json");
+		expect(calls[0]?.body).toEqual({ content: '{"openapi":"3.1"}' });
+	});
+});
+
+describe("import.openapi", () => {
+	it("POST /import/openapi?workspace={id}", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { collections: [{ id: "c2", uid: "c2-uid", name: "Imported" }] } },
+		]);
+		const spec = { openapi: "3.0.0", info: { title: "My API" } };
+		const result = await client.import.openapi("ws1", spec);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/import/openapi");
+		expect(calls[0]?.url).toContain("workspace=ws1");
+		expect(calls[0]?.body).toMatchObject({ type: "string" });
+		expect(result.collections[0]?.name).toBe("Imported");
+	});
+});

--- a/packages/postman-client/src/__tests__/resources.test.ts
+++ b/packages/postman-client/src/__tests__/resources.test.ts
@@ -12,7 +12,11 @@ function makeClient(responses: Parameters<typeof stubFetch>[0]) {
 describe("me.get", () => {
 	it("GET /me", async () => {
 		const { client, calls } = makeClient([
-			{ body: { user: { id: 1, username: "newton", email: "n@example.com" } } },
+			{
+				body: {
+					user: { id: 1, username: "newton", email: "n@example.com" },
+				},
+			},
 		]);
 		const result = await client.me.get();
 		expect(calls[0]?.method).toBe("GET");
@@ -24,7 +28,13 @@ describe("me.get", () => {
 describe("workspaces.list", () => {
 	it("GET /workspaces", async () => {
 		const { client, calls } = makeClient([
-			{ body: { workspaces: [{ id: "ws1", name: "My Workspace", type: "personal" }] } },
+			{
+				body: {
+					workspaces: [
+						{ id: "ws1", name: "My Workspace", type: "personal" },
+					],
+				},
+			},
 		]);
 		const result = await client.workspaces.list();
 		expect(calls[0]?.method).toBe("GET");
@@ -36,7 +46,11 @@ describe("workspaces.list", () => {
 describe("collections.list", () => {
 	it("GET /collections?workspace={id}", async () => {
 		const { client, calls } = makeClient([
-			{ body: { collections: [{ id: "c1", uid: "c1-uid", name: "My API" }] } },
+			{
+				body: {
+					collections: [{ id: "c1", uid: "c1-uid", name: "My API" }],
+				},
+			},
 		]);
 		const result = await client.collections.list("ws1");
 		expect(calls[0]?.method).toBe("GET");
@@ -58,7 +72,13 @@ describe("collections.delete", () => {
 describe("environments.list", () => {
 	it("GET /environments?workspace={id}", async () => {
 		const { client, calls } = makeClient([
-			{ body: { environments: [{ id: "e1", uid: "e1-uid", name: "Production" }] } },
+			{
+				body: {
+					environments: [
+						{ id: "e1", uid: "e1-uid", name: "Production" },
+					],
+				},
+			},
 		]);
 		const result = await client.environments.list("ws1");
 		expect(calls[0]?.url).toContain("/environments");
@@ -70,7 +90,12 @@ describe("environments.list", () => {
 describe("environments.create", () => {
 	it("POST /environments?workspace={id}", async () => {
 		const { client, calls } = makeClient([
-			{ status: 200, body: { environment: { id: "e2", uid: "e2-uid", name: "Staging" } } },
+			{
+				status: 200,
+				body: {
+					environment: { id: "e2", uid: "e2-uid", name: "Staging" },
+				},
+			},
 		]);
 		const env = { name: "Staging", values: [] };
 		await client.environments.create("ws1", env);
@@ -84,9 +109,21 @@ describe("environments.create", () => {
 describe("environments.update", () => {
 	it("PUT /environments/{uid}", async () => {
 		const { client, calls } = makeClient([
-			{ status: 200, body: { environment: { id: "e1", uid: "e1-uid", name: "Production" } } },
+			{
+				status: 200,
+				body: {
+					environment: {
+						id: "e1",
+						uid: "e1-uid",
+						name: "Production",
+					},
+				},
+			},
 		]);
-		const env = { name: "Production", values: [{ key: "URL", value: "https://prod" }] };
+		const env = {
+			name: "Production",
+			values: [{ key: "URL", value: "https://prod" }],
+		};
 		await client.environments.update("e1-uid", env);
 		expect(calls[0]?.method).toBe("PUT");
 		expect(calls[0]?.url).toContain("/environments/e1-uid");
@@ -97,7 +134,13 @@ describe("environments.update", () => {
 describe("specs.list", () => {
 	it("GET /specs?workspaceId={id}", async () => {
 		const { client, calls } = makeClient([
-			{ body: { specs: [{ id: "s1", name: "My API Spec", type: "OPENAPI:3.0" }] } },
+			{
+				body: {
+					specs: [
+						{ id: "s1", name: "My API Spec", type: "OPENAPI:3.0" },
+					],
+				},
+			},
 		]);
 		const result = await client.specs.list("ws1");
 		expect(calls[0]?.url).toContain("/specs");
@@ -109,9 +152,15 @@ describe("specs.list", () => {
 describe("specs.create", () => {
 	it("POST /specs?workspaceId={id} with name + files", async () => {
 		const { client, calls } = makeClient([
-			{ status: 200, body: { id: "s2", name: "New Spec", type: "OPENAPI:3.0" } },
+			{
+				status: 200,
+				body: { id: "s2", name: "New Spec", type: "OPENAPI:3.0" },
+			},
 		]);
-		await client.specs.create("ws1", { name: "New Spec", fileContent: '{"openapi":"3.0"}' });
+		await client.specs.create("ws1", {
+			name: "New Spec",
+			fileContent: '{"openapi":"3.0"}',
+		});
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/specs");
 		expect(calls[0]?.url).toContain("workspaceId=ws1");
@@ -136,7 +185,14 @@ describe("specs.updateFile", () => {
 describe("import.openapi", () => {
 	it("POST /import/openapi?workspace={id}", async () => {
 		const { client, calls } = makeClient([
-			{ status: 200, body: { collections: [{ id: "c2", uid: "c2-uid", name: "Imported" }] } },
+			{
+				status: 200,
+				body: {
+					collections: [
+						{ id: "c2", uid: "c2-uid", name: "Imported" },
+					],
+				},
+			},
 		]);
 		const spec = { openapi: "3.0.0", info: { title: "My API" } };
 		const result = await client.import.openapi("ws1", spec);

--- a/packages/postman-client/src/collections/collections.ts
+++ b/packages/postman-client/src/collections/collections.ts
@@ -1,0 +1,25 @@
+import type { RestClient } from "../utils.js";
+
+export interface PostmanCollection {
+	id: string;
+	uid: string;
+	name: string;
+}
+
+export interface PostmanCollectionsResponse {
+	collections: PostmanCollection[];
+}
+
+export function collections(rest: RestClient) {
+	return {
+		list: (workspaceId: string): Promise<PostmanCollectionsResponse> =>
+			rest.request<PostmanCollectionsResponse>("/collections", {
+				query: { workspace: workspaceId },
+			}),
+
+		delete: (uid: string): Promise<void> =>
+			rest.request<void>(`/collections/${encodeURIComponent(uid)}`, {
+				method: "DELETE",
+			}),
+	};
+}

--- a/packages/postman-client/src/environments/environments.ts
+++ b/packages/postman-client/src/environments/environments.ts
@@ -1,0 +1,37 @@
+import type { RestClient } from "../utils.js";
+
+export interface PostmanEnvironment {
+	id: string;
+	uid: string;
+	name: string;
+}
+
+export interface PostmanEnvironmentsResponse {
+	environments: PostmanEnvironment[];
+}
+
+export interface PostmanEnvironmentResponse {
+	environment: PostmanEnvironment;
+}
+
+export function environments(rest: RestClient) {
+	return {
+		list: (workspaceId: string): Promise<PostmanEnvironmentsResponse> =>
+			rest.request<PostmanEnvironmentsResponse>("/environments", {
+				query: { workspace: workspaceId },
+			}),
+
+		create: (workspaceId: string, environment: unknown): Promise<PostmanEnvironmentResponse> =>
+			rest.request<PostmanEnvironmentResponse>("/environments", {
+				method: "POST",
+				query: { workspace: workspaceId },
+				body: { environment },
+			}),
+
+		update: (uid: string, environment: unknown): Promise<PostmanEnvironmentResponse> =>
+			rest.request<PostmanEnvironmentResponse>(`/environments/${encodeURIComponent(uid)}`, {
+				method: "PUT",
+				body: { environment },
+			}),
+	};
+}

--- a/packages/postman-client/src/environments/environments.ts
+++ b/packages/postman-client/src/environments/environments.ts
@@ -21,17 +21,26 @@ export function environments(rest: RestClient) {
 				query: { workspace: workspaceId },
 			}),
 
-		create: (workspaceId: string, environment: unknown): Promise<PostmanEnvironmentResponse> =>
+		create: (
+			workspaceId: string,
+			environment: unknown,
+		): Promise<PostmanEnvironmentResponse> =>
 			rest.request<PostmanEnvironmentResponse>("/environments", {
 				method: "POST",
 				query: { workspace: workspaceId },
 				body: { environment },
 			}),
 
-		update: (uid: string, environment: unknown): Promise<PostmanEnvironmentResponse> =>
-			rest.request<PostmanEnvironmentResponse>(`/environments/${encodeURIComponent(uid)}`, {
-				method: "PUT",
-				body: { environment },
-			}),
+		update: (
+			uid: string,
+			environment: unknown,
+		): Promise<PostmanEnvironmentResponse> =>
+			rest.request<PostmanEnvironmentResponse>(
+				`/environments/${encodeURIComponent(uid)}`,
+				{
+					method: "PUT",
+					body: { environment },
+				},
+			),
 	};
 }

--- a/packages/postman-client/src/errors.ts
+++ b/packages/postman-client/src/errors.ts
@@ -7,7 +7,7 @@ export class PostmanPlanLimitError extends Error {
 
 	constructor(
 		readonly limitMessage: string,
-		readonly body: string
+		readonly body: string,
 	) {
 		super(limitMessage);
 	}
@@ -15,8 +15,13 @@ export class PostmanPlanLimitError extends Error {
 
 export function detectPlanLimit(body: string): string | null {
 	try {
-		const parsed = JSON.parse(body) as { error?: { name?: string; message?: string } };
-		if (parsed.error?.name === "limitReachedError" && parsed.error.message) {
+		const parsed = JSON.parse(body) as {
+			error?: { name?: string; message?: string };
+		};
+		if (
+			parsed.error?.name === "limitReachedError" &&
+			parsed.error.message
+		) {
 			return parsed.error.message;
 		}
 	} catch {

--- a/packages/postman-client/src/errors.ts
+++ b/packages/postman-client/src/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Thrown when Postman returns a `limitReachedError` (e.g., a Free-tier
+ * account hitting the "0 APIs" cap).
+ */
+export class PostmanPlanLimitError extends Error {
+	override name = "PostmanPlanLimitError";
+
+	constructor(
+		readonly limitMessage: string,
+		readonly body: string
+	) {
+		super(limitMessage);
+	}
+}
+
+export function detectPlanLimit(body: string): string | null {
+	try {
+		const parsed = JSON.parse(body) as { error?: { name?: string; message?: string } };
+		if (parsed.error?.name === "limitReachedError" && parsed.error.message) {
+			return parsed.error.message;
+		}
+	} catch {
+		// Not JSON — fall through.
+	}
+	return null;
+}

--- a/packages/postman-client/src/import/import.ts
+++ b/packages/postman-client/src/import/import.ts
@@ -1,0 +1,20 @@
+import type { RestClient } from "../utils.js";
+import type { PostmanCollection } from "../collections/collections.js";
+
+export interface PostmanImportOpenApiResponse {
+	collections: PostmanCollection[];
+}
+
+export function importApi(rest: RestClient) {
+	return {
+		openapi: (workspaceId: string, spec: unknown): Promise<PostmanImportOpenApiResponse> =>
+			rest.request<PostmanImportOpenApiResponse>("/import/openapi", {
+				method: "POST",
+				query: { workspace: workspaceId },
+				body: {
+					type: "string",
+					input: typeof spec === "string" ? spec : JSON.stringify(spec),
+				},
+			}),
+	};
+}

--- a/packages/postman-client/src/import/import.ts
+++ b/packages/postman-client/src/import/import.ts
@@ -7,13 +7,17 @@ export interface PostmanImportOpenApiResponse {
 
 export function importApi(rest: RestClient) {
 	return {
-		openapi: (workspaceId: string, spec: unknown): Promise<PostmanImportOpenApiResponse> =>
+		openapi: (
+			workspaceId: string,
+			spec: unknown,
+		): Promise<PostmanImportOpenApiResponse> =>
 			rest.request<PostmanImportOpenApiResponse>("/import/openapi", {
 				method: "POST",
 				query: { workspace: workspaceId },
 				body: {
 					type: "string",
-					input: typeof spec === "string" ? spec : JSON.stringify(spec),
+					input:
+						typeof spec === "string" ? spec : JSON.stringify(spec),
 				},
 			}),
 	};

--- a/packages/postman-client/src/index.ts
+++ b/packages/postman-client/src/index.ts
@@ -1,0 +1,42 @@
+import { createPostmanRestClient, type PostmanClientOptions } from "./utils.js";
+import { collections } from "./collections/collections.js";
+import { environments } from "./environments/environments.js";
+import { importApi } from "./import/import.js";
+import { me } from "./me/me.js";
+import { specs } from "./specs/specs.js";
+import { workspaces } from "./workspaces/workspaces.js";
+
+export type { PostmanClientOptions } from "./utils.js";
+export { PostmanPlanLimitError, detectPlanLimit } from "./errors.js";
+
+export type {
+	PostmanCollection,
+	PostmanCollectionsResponse,
+} from "./collections/collections.js";
+export type {
+	PostmanEnvironment,
+	PostmanEnvironmentsResponse,
+	PostmanEnvironmentResponse,
+} from "./environments/environments.js";
+export type { PostmanImportOpenApiResponse } from "./import/import.js";
+export type { PostmanUser, PostmanMeResponse } from "./me/me.js";
+export type {
+	PostmanSpec,
+	PostmanSpecsResponse,
+	PostmanCreateSpecInput,
+} from "./specs/specs.js";
+export type { PostmanWorkspace, PostmanWorkspacesResponse } from "./workspaces/workspaces.js";
+
+export function createPostmanClient(opts: PostmanClientOptions) {
+	const rest = createPostmanRestClient(opts);
+	return {
+		collections: collections(rest),
+		environments: environments(rest),
+		import: importApi(rest),
+		me: me(rest),
+		specs: specs(rest),
+		workspaces: workspaces(rest),
+	};
+}
+
+export type PostmanClient = ReturnType<typeof createPostmanClient>;

--- a/packages/postman-client/src/index.ts
+++ b/packages/postman-client/src/index.ts
@@ -25,7 +25,10 @@ export type {
 	PostmanSpecsResponse,
 	PostmanCreateSpecInput,
 } from "./specs/specs.js";
-export type { PostmanWorkspace, PostmanWorkspacesResponse } from "./workspaces/workspaces.js";
+export type {
+	PostmanWorkspace,
+	PostmanWorkspacesResponse,
+} from "./workspaces/workspaces.js";
 
 export function createPostmanClient(opts: PostmanClientOptions) {
 	const rest = createPostmanRestClient(opts);

--- a/packages/postman-client/src/me/me.ts
+++ b/packages/postman-client/src/me/me.ts
@@ -1,0 +1,18 @@
+import type { RestClient } from "../utils.js";
+
+export interface PostmanUser {
+	id?: number | string;
+	username?: string;
+	email?: string;
+	fullName?: string;
+}
+
+export interface PostmanMeResponse {
+	user?: PostmanUser;
+}
+
+export function me(rest: RestClient) {
+	return {
+		get: (): Promise<PostmanMeResponse> => rest.request<PostmanMeResponse>("/me"),
+	};
+}

--- a/packages/postman-client/src/me/me.ts
+++ b/packages/postman-client/src/me/me.ts
@@ -13,6 +13,7 @@ export interface PostmanMeResponse {
 
 export function me(rest: RestClient) {
 	return {
-		get: (): Promise<PostmanMeResponse> => rest.request<PostmanMeResponse>("/me"),
+		get: (): Promise<PostmanMeResponse> =>
+			rest.request<PostmanMeResponse>("/me"),
 	};
 }

--- a/packages/postman-client/src/specs/specs.ts
+++ b/packages/postman-client/src/specs/specs.ts
@@ -24,21 +24,33 @@ export function specs(rest: RestClient) {
 				query: { workspaceId },
 			}),
 
-		create: (workspaceId: string, input: PostmanCreateSpecInput): Promise<PostmanSpec> =>
+		create: (
+			workspaceId: string,
+			input: PostmanCreateSpecInput,
+		): Promise<PostmanSpec> =>
 			rest.request<PostmanSpec>("/specs", {
 				method: "POST",
 				query: { workspaceId },
 				body: {
 					name: input.name,
 					type: input.type ?? "OPENAPI:3.0",
-					files: [{ path: input.filePath ?? "index.json", content: input.fileContent }],
+					files: [
+						{
+							path: input.filePath ?? "index.json",
+							content: input.fileContent,
+						},
+					],
 				},
 			}),
 
-		updateFile: (specId: string, filePath: string, content: string): Promise<void> =>
+		updateFile: (
+			specId: string,
+			filePath: string,
+			content: string,
+		): Promise<void> =>
 			rest.request<void>(
 				`/specs/${encodeURIComponent(specId)}/files/${encodeURIComponent(filePath)}`,
-				{ method: "PATCH", body: { content } }
+				{ method: "PATCH", body: { content } },
 			),
 	};
 }

--- a/packages/postman-client/src/specs/specs.ts
+++ b/packages/postman-client/src/specs/specs.ts
@@ -1,0 +1,44 @@
+import type { RestClient } from "../utils.js";
+
+export interface PostmanSpec {
+	id: string;
+	name: string;
+	type: string;
+}
+
+export interface PostmanSpecsResponse {
+	specs: PostmanSpec[];
+}
+
+export interface PostmanCreateSpecInput {
+	name: string;
+	fileContent: string;
+	type?: string;
+	filePath?: string;
+}
+
+export function specs(rest: RestClient) {
+	return {
+		list: (workspaceId: string): Promise<PostmanSpecsResponse> =>
+			rest.request<PostmanSpecsResponse>("/specs", {
+				query: { workspaceId },
+			}),
+
+		create: (workspaceId: string, input: PostmanCreateSpecInput): Promise<PostmanSpec> =>
+			rest.request<PostmanSpec>("/specs", {
+				method: "POST",
+				query: { workspaceId },
+				body: {
+					name: input.name,
+					type: input.type ?? "OPENAPI:3.0",
+					files: [{ path: input.filePath ?? "index.json", content: input.fileContent }],
+				},
+			}),
+
+		updateFile: (specId: string, filePath: string, content: string): Promise<void> =>
+			rest.request<void>(
+				`/specs/${encodeURIComponent(specId)}/files/${encodeURIComponent(filePath)}`,
+				{ method: "PATCH", body: { content } }
+			),
+	};
+}

--- a/packages/postman-client/src/utils.ts
+++ b/packages/postman-client/src/utils.ts
@@ -1,0 +1,41 @@
+import { createRestClient, type RequestOptions, type RestClient } from "@theholocron/http-client";
+
+import { PostmanPlanLimitError, detectPlanLimit } from "./errors.js";
+
+export type { RestClient };
+
+export interface PostmanClientOptions {
+	/** Postman API key. */
+	token: string;
+	/** Override base URL for testing. Defaults to https://api.getpostman.com. */
+	baseUrl?: string;
+	/** Override fetch for testing. Defaults to globalThis.fetch. */
+	fetch?: typeof fetch;
+}
+
+export function createPostmanRestClient(opts: PostmanClientOptions): RestClient {
+	const base = createRestClient({
+		baseUrl: opts.baseUrl ?? "https://api.getpostman.com",
+		token: opts.token,
+		tokenScheme: "apikey",
+		apiKeyHeader: "x-api-key",
+		vendor: "Postman",
+		fetch: opts.fetch,
+	});
+
+	return {
+		baseUrl: base.baseUrl,
+		async request<T>(path: string, reqOpts?: RequestOptions): Promise<T> {
+			try {
+				return await base.request<T>(path, reqOpts);
+			} catch (err: unknown) {
+				const details = (err as { details?: string }).details;
+				if (typeof details === "string") {
+					const limit = detectPlanLimit(details);
+					if (limit) throw new PostmanPlanLimitError(limit, details);
+				}
+				throw err;
+			}
+		},
+	};
+}

--- a/packages/postman-client/src/utils.ts
+++ b/packages/postman-client/src/utils.ts
@@ -1,4 +1,8 @@
-import { createRestClient, type RequestOptions, type RestClient } from "@theholocron/http-client";
+import {
+	createRestClient,
+	type RequestOptions,
+	type RestClient,
+} from "@theholocron/http-client";
 
 import { PostmanPlanLimitError, detectPlanLimit } from "./errors.js";
 
@@ -13,7 +17,9 @@ export interface PostmanClientOptions {
 	fetch?: typeof fetch;
 }
 
-export function createPostmanRestClient(opts: PostmanClientOptions): RestClient {
+export function createPostmanRestClient(
+	opts: PostmanClientOptions,
+): RestClient {
 	const base = createRestClient({
 		baseUrl: opts.baseUrl ?? "https://api.getpostman.com",
 		token: opts.token,

--- a/packages/postman-client/src/workspaces/workspaces.ts
+++ b/packages/postman-client/src/workspaces/workspaces.ts
@@ -1,0 +1,18 @@
+import type { RestClient } from "../utils.js";
+
+export interface PostmanWorkspace {
+	id: string;
+	name: string;
+	type: string;
+}
+
+export interface PostmanWorkspacesResponse {
+	workspaces: PostmanWorkspace[];
+}
+
+export function workspaces(rest: RestClient) {
+	return {
+		list: (): Promise<PostmanWorkspacesResponse> =>
+			rest.request<PostmanWorkspacesResponse>("/workspaces"),
+	};
+}

--- a/packages/postman-client/tsconfig.json
+++ b/packages/postman-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "display": "Postman API Client",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "baseUrl": "./", "outDir": "./dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/postman-client/tsdown.config.ts
+++ b/packages/postman-client/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/postman-client/vitest.config.ts
+++ b/packages/postman-client/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,52 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/postman-client:
+    dependencies:
+      '@theholocron/http-client':
+        specifier: ^0.8.0
+        version: 0.8.1
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 7.0.0(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: 'catalog:'
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.6.1)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/zendesk-client:
     dependencies:
       '@theholocron/http-client':
@@ -1323,6 +1369,10 @@ packages:
 
   '@theholocron/http-client@0.7.0':
     resolution: {integrity: sha512-D2zC97WwBtMSrfKFtZM3GPVHxbuTJeMDjBH/JxlcB5YYSUzWX+LXrN8GrcHgm9heOPcwEf2GOGN6K9+DBq8Ntg==}
+    engines: {node: '>=22.0.0'}
+
+  '@theholocron/http-client@0.8.1':
+    resolution: {integrity: sha512-V/wvtME8BjEM532kmASHOrta2c8l1rXsyavOWy9M+0QqrFZaEgrD1LDSB2TT4iuxpNdpeUR0d86b7ow7xgVOeg==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@7.0.0':
@@ -4527,6 +4577,8 @@ snapshots:
   '@theholocron/http-client@0.6.0': {}
 
   '@theholocron/http-client@0.7.0': {}
+
+  '@theholocron/http-client@0.8.1': {}
 
   '@theholocron/lint-staged-config@7.0.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:

--- a/release.config.ts
+++ b/release.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/doppler-client','packages/github-client','packages/google-client','packages/http-client','packages/infisical-client','packages/jira-client','packages/neon-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/doppler-client','packages/github-client','packages/google-client','packages/http-client','packages/infisical-client','packages/jira-client','packages/neon-client','packages/postman-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
## Summary

- Adds `@theholocron/postman-client` — typed TypeScript client for the [Postman API](https://api.getpostman.com)
- 6 resource groups covering everything `holocron-plugin-postman` uses:
  - **`me`** — `get()`
  - **`workspaces`** — `list()`
  - **`collections`** — `list(workspaceId)`, `delete(uid)`
  - **`environments`** — `list(workspaceId)`, `create(workspaceId, env)`, `update(uid, env)`
  - **`specs`** — `list(workspaceId)`, `create(workspaceId, input)`, `updateFile(specId, filePath, content)`
  - **`import`** — `openapi(workspaceId, spec)`
- Auth uses `x-api-key` header (not Bearer) via `tokenScheme: "apikey"`
- `PostmanPlanLimitError` + `detectPlanLimit` moved into this package so the plugin can import them from here
- Registered in `release.config.ts` prepareCmd; version set to `0.8.0`
- 15 tests, all passing; typecheck + lint + build clean

## Test plan

- [x] `pnpm --filter @theholocron/postman-client test` — 15 tests pass
- [x] `pnpm --filter @theholocron/postman-client typecheck` — clean
- [x] `pnpm --filter @theholocron/postman-client lint` — clean
- [x] `pnpm --filter @theholocron/postman-client build` — dist emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->