### PR TITLE
feat: add @theholocron/vercel-client

### DIFF
--- a/packages/vercel-client/README.md
+++ b/packages/vercel-client/README.md
@@ -1,0 +1,62 @@
+# `@theholocron/vercel-client`
+
+TypeScript client for the [Vercel API](https://vercel.com/docs/rest-api).
+
+## Install
+
+```bash
+pnpm add @theholocron/vercel-client
+```
+
+## Usage
+
+```ts
+import { createVercelClient } from "@theholocron/vercel-client";
+
+const vercel = createVercelClient({
+  token: process.env.VERCEL_TOKEN!,
+  teamId: process.env.VERCEL_TEAM_ID, // optional; appended to every request
+});
+
+// Get the authenticated user
+const { user } = await vercel.user.get();
+
+// List projects
+const { projects } = await vercel.projects.list();
+
+// Get a project by name or id
+const project = await vercel.projects.get("my-app");
+
+// Create a project
+const created = await vercel.projects.create({
+  name: "my-app",
+  framework: "nextjs",
+  repo: "org/repo",
+});
+
+// Update project settings
+await vercel.projects.update("project-id", {
+  previewDeploymentsDisabled: true,
+});
+
+// List env vars
+const { envs } = await vercel.env.list("project-id");
+
+// Set (upsert) an env var
+await vercel.env.set("project-id", "production", "API_URL", "https://api.example.com");
+
+// Trigger a deployment
+const deployment = await vercel.deployments.trigger({
+  projectName: "my-app",
+  branch: "main",
+  repoId: project.link?.repoId!,
+  target: "production",
+});
+
+// Poll deployment status
+const status = await vercel.deployments.get(deployment.id);
+```
+
+## Status
+
+`v0.9.0` — published on npm. APIs may shift before v1.

--- a/packages/vercel-client/README.md
+++ b/packages/vercel-client/README.md
@@ -43,7 +43,12 @@ await vercel.projects.update("project-id", {
 const { envs } = await vercel.env.list("project-id");
 
 // Set (upsert) an env var
-await vercel.env.set("project-id", "production", "API_URL", "https://api.example.com");
+await vercel.env.set(
+  "project-id",
+  "production",
+  "API_URL",
+  "https://api.example.com",
+);
 
 // Trigger a deployment
 const deployment = await vercel.deployments.trigger({

--- a/packages/vercel-client/eslint.config.ts
+++ b/packages/vercel-client/eslint.config.ts
@@ -1,0 +1,14 @@
+import type { Linter } from "eslint";
+import { library } from "@theholocron/eslint-config/bundles/library";
+
+const config = [
+	...library(),
+	{
+		rules: {
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+] satisfies Linter.Config[];
+
+export default config;

--- a/packages/vercel-client/package.json
+++ b/packages/vercel-client/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/vercel-client",
+  "version": "0.9.0",
+  "description": "A TypeScript client for the Vercel API",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/vercel-client#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/vercel-client"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@theholocron/http-client": "^0.9.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "@theholocron/vitest-config": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/vercel-client/src/__tests__/client.test.ts
+++ b/packages/vercel-client/src/__tests__/client.test.ts
@@ -21,7 +21,11 @@ describe("createVercelClient", () => {
 
 	it("appends teamId to every request when provided", async () => {
 		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
-		const client = createVercelClient({ token: TOKEN, teamId: "team_abc", fetch });
+		const client = createVercelClient({
+			token: TOKEN,
+			teamId: "team_abc",
+			fetch,
+		});
 		await client.user.get();
 		expect(calls[0]?.url).toContain("teamId=team_abc");
 	});

--- a/packages/vercel-client/src/__tests__/client.test.ts
+++ b/packages/vercel-client/src/__tests__/client.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { createVercelClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "vercel-test-token";
+
+describe("createVercelClient", () => {
+	it("sends Bearer authorization header", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createVercelClient({ token: TOKEN, fetch });
+		await client.user.get();
+		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+	});
+
+	it("targets the Vercel base URL", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createVercelClient({ token: TOKEN, fetch });
+		await client.user.get();
+		expect(calls[0]?.url).toContain("https://api.vercel.com");
+	});
+
+	it("appends teamId to every request when provided", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createVercelClient({ token: TOKEN, teamId: "team_abc", fetch });
+		await client.user.get();
+		expect(calls[0]?.url).toContain("teamId=team_abc");
+	});
+
+	it("omits teamId when not provided", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createVercelClient({ token: TOKEN, fetch });
+		await client.user.get();
+		expect(calls[0]?.url).not.toContain("teamId");
+	});
+
+	it("respects baseUrl override", async () => {
+		const { fetch, calls } = stubFetch([{ body: { user: {} } }]);
+		const client = createVercelClient({
+			token: TOKEN,
+			baseUrl: "https://vercel.test.invalid",
+			fetch,
+		});
+		await client.user.get();
+		expect(calls[0]?.url).toContain("https://vercel.test.invalid");
+	});
+});

--- a/packages/vercel-client/src/__tests__/helpers.ts
+++ b/packages/vercel-client/src/__tests__/helpers.ts
@@ -1,0 +1,34 @@
+import { vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export function stubFetch(
+	responses: Array<{ status?: number; body?: unknown; text?: string }>,
+) {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body =
+			typeof init?.body === "string"
+				? JSON.parse(init.body)
+				: (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204) return new Response(null, { status });
+		const text = next.text ?? JSON.stringify(next.body ?? {});
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls };
+}

--- a/packages/vercel-client/src/__tests__/resources.test.ts
+++ b/packages/vercel-client/src/__tests__/resources.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { createVercelClient } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+const TOKEN = "vercel-test-token";
+
+function makeClient(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	return { client: createVercelClient({ token: TOKEN, fetch }), calls };
+}
+
+describe("user.get", () => {
+	it("GET /v2/user", async () => {
+		const { client, calls } = makeClient([
+			{ body: { user: { id: "u1", email: "n@example.com", username: "newton" } } },
+		]);
+		const result = await client.user.get();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/v2/user");
+		expect(result.user?.username).toBe("newton");
+	});
+});
+
+describe("projects.list", () => {
+	it("GET /v10/projects", async () => {
+		const { client, calls } = makeClient([
+			{ body: { projects: [{ id: "p1", name: "my-app" }] } },
+		]);
+		const result = await client.projects.list();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/v10/projects");
+		expect(result.projects[0]?.name).toBe("my-app");
+	});
+});
+
+describe("projects.get", () => {
+	it("GET /v10/projects/{nameOrId}", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "p1", name: "my-app", framework: "nextjs" } },
+		]);
+		const result = await client.projects.get("my-app");
+		expect(calls[0]?.url).toContain("/v10/projects/my-app");
+		expect(result.framework).toBe("nextjs");
+	});
+});
+
+describe("projects.create", () => {
+	it("POST /v11/projects with name and framework", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { id: "p2", name: "new-app", framework: "nextjs" } },
+		]);
+		await client.projects.create({ name: "new-app", framework: "nextjs" });
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/v11/projects");
+		expect(calls[0]?.body).toMatchObject({ name: "new-app", framework: "nextjs" });
+	});
+
+	it("includes gitRepository when repo is provided", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "p2", name: "new-app" } },
+		]);
+		await client.projects.create({ name: "new-app", repo: "org/repo" });
+		expect(calls[0]?.body).toMatchObject({
+			gitRepository: { type: "github", repo: "org/repo" },
+		});
+	});
+});
+
+describe("projects.update", () => {
+	it("PATCH /v9/projects/{id}", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "p1", name: "my-app" } },
+		]);
+		await client.projects.update("p1", { previewDeploymentsDisabled: true });
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/v9/projects/p1");
+		expect(calls[0]?.body).toMatchObject({ previewDeploymentsDisabled: true });
+	});
+});
+
+describe("env.list", () => {
+	it("GET /v9/projects/{id}/env", async () => {
+		const { client, calls } = makeClient([
+			{ body: { envs: [{ id: "e1", key: "API_URL", target: ["production"] }] } },
+		]);
+		const result = await client.env.list("p1");
+		expect(calls[0]?.url).toContain("/v9/projects/p1/env");
+		expect(result.envs[0]?.key).toBe("API_URL");
+	});
+});
+
+describe("env.set", () => {
+	it("POST /v10/projects/{id}/env?upsert=true", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "e2", key: "DB_URL", target: ["production"] } },
+		]);
+		await client.env.set("p1", "production", "DB_URL", "postgres://...");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/v10/projects/p1/env");
+		expect(calls[0]?.url).toContain("upsert=true");
+		expect(calls[0]?.body).toMatchObject({
+			key: "DB_URL",
+			value: "postgres://...",
+			target: ["production"],
+			type: "encrypted",
+		});
+	});
+});
+
+describe("deployments.trigger", () => {
+	it("POST /v13/deployments with gitSource", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "d1", url: "my-app.vercel.app", readyState: "BUILDING" } },
+		]);
+		const result = await client.deployments.trigger({
+			projectName: "my-app",
+			branch: "main",
+			repoId: 12345,
+		});
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/v13/deployments");
+		expect(calls[0]?.body).toMatchObject({
+			name: "my-app",
+			gitSource: { type: "github", ref: "main", repoId: 12345 },
+		});
+		expect(result.id).toBe("d1");
+	});
+
+	it("includes target when provided", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "d1", url: "my-app.vercel.app", readyState: "QUEUED" } },
+		]);
+		await client.deployments.trigger({
+			projectName: "my-app",
+			branch: "main",
+			repoId: 12345,
+			target: "production",
+		});
+		expect(calls[0]?.body).toMatchObject({ target: "production" });
+	});
+});
+
+describe("deployments.get", () => {
+	it("GET /v13/deployments/{id}", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "d1", url: "my-app.vercel.app", readyState: "READY" } },
+		]);
+		const result = await client.deployments.get("d1");
+		expect(calls[0]?.url).toContain("/v13/deployments/d1");
+		expect(result.readyState).toBe("READY");
+	});
+});

--- a/packages/vercel-client/src/__tests__/resources.test.ts
+++ b/packages/vercel-client/src/__tests__/resources.test.ts
@@ -12,7 +12,15 @@ function makeClient(responses: Parameters<typeof stubFetch>[0]) {
 describe("user.get", () => {
 	it("GET /v2/user", async () => {
 		const { client, calls } = makeClient([
-			{ body: { user: { id: "u1", email: "n@example.com", username: "newton" } } },
+			{
+				body: {
+					user: {
+						id: "u1",
+						email: "n@example.com",
+						username: "newton",
+					},
+				},
+			},
 		]);
 		const result = await client.user.get();
 		expect(calls[0]?.method).toBe("GET");
@@ -47,12 +55,18 @@ describe("projects.get", () => {
 describe("projects.create", () => {
 	it("POST /v11/projects with name and framework", async () => {
 		const { client, calls } = makeClient([
-			{ status: 200, body: { id: "p2", name: "new-app", framework: "nextjs" } },
+			{
+				status: 200,
+				body: { id: "p2", name: "new-app", framework: "nextjs" },
+			},
 		]);
 		await client.projects.create({ name: "new-app", framework: "nextjs" });
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/v11/projects");
-		expect(calls[0]?.body).toMatchObject({ name: "new-app", framework: "nextjs" });
+		expect(calls[0]?.body).toMatchObject({
+			name: "new-app",
+			framework: "nextjs",
+		});
 	});
 
 	it("includes gitRepository when repo is provided", async () => {
@@ -71,17 +85,27 @@ describe("projects.update", () => {
 		const { client, calls } = makeClient([
 			{ body: { id: "p1", name: "my-app" } },
 		]);
-		await client.projects.update("p1", { previewDeploymentsDisabled: true });
+		await client.projects.update("p1", {
+			previewDeploymentsDisabled: true,
+		});
 		expect(calls[0]?.method).toBe("PATCH");
 		expect(calls[0]?.url).toContain("/v9/projects/p1");
-		expect(calls[0]?.body).toMatchObject({ previewDeploymentsDisabled: true });
+		expect(calls[0]?.body).toMatchObject({
+			previewDeploymentsDisabled: true,
+		});
 	});
 });
 
 describe("env.list", () => {
 	it("GET /v9/projects/{id}/env", async () => {
 		const { client, calls } = makeClient([
-			{ body: { envs: [{ id: "e1", key: "API_URL", target: ["production"] }] } },
+			{
+				body: {
+					envs: [
+						{ id: "e1", key: "API_URL", target: ["production"] },
+					],
+				},
+			},
 		]);
 		const result = await client.env.list("p1");
 		expect(calls[0]?.url).toContain("/v9/projects/p1/env");
@@ -110,7 +134,13 @@ describe("env.set", () => {
 describe("deployments.trigger", () => {
 	it("POST /v13/deployments with gitSource", async () => {
 		const { client, calls } = makeClient([
-			{ body: { id: "d1", url: "my-app.vercel.app", readyState: "BUILDING" } },
+			{
+				body: {
+					id: "d1",
+					url: "my-app.vercel.app",
+					readyState: "BUILDING",
+				},
+			},
 		]);
 		const result = await client.deployments.trigger({
 			projectName: "my-app",
@@ -128,7 +158,13 @@ describe("deployments.trigger", () => {
 
 	it("includes target when provided", async () => {
 		const { client, calls } = makeClient([
-			{ body: { id: "d1", url: "my-app.vercel.app", readyState: "QUEUED" } },
+			{
+				body: {
+					id: "d1",
+					url: "my-app.vercel.app",
+					readyState: "QUEUED",
+				},
+			},
 		]);
 		await client.deployments.trigger({
 			projectName: "my-app",
@@ -143,7 +179,13 @@ describe("deployments.trigger", () => {
 describe("deployments.get", () => {
 	it("GET /v13/deployments/{id}", async () => {
 		const { client, calls } = makeClient([
-			{ body: { id: "d1", url: "my-app.vercel.app", readyState: "READY" } },
+			{
+				body: {
+					id: "d1",
+					url: "my-app.vercel.app",
+					readyState: "READY",
+				},
+			},
 		]);
 		const result = await client.deployments.get("d1");
 		expect(calls[0]?.url).toContain("/v13/deployments/d1");

--- a/packages/vercel-client/src/deployments/deployments.ts
+++ b/packages/vercel-client/src/deployments/deployments.ts
@@ -1,0 +1,45 @@
+import type { RestClient } from "../utils.js";
+
+export type VercelDeploymentState =
+	| "INITIALIZING"
+	| "QUEUED"
+	| "BUILDING"
+	| "READY"
+	| "ERROR"
+	| "CANCELED";
+
+export type VercelDeploymentTarget = "production" | "staging";
+
+export interface VercelDeployment {
+	id: string;
+	url: string;
+	readyState: VercelDeploymentState;
+	target?: VercelDeploymentTarget | null;
+	meta?: { githubCommitRef?: string };
+}
+
+export interface VercelTriggerDeploymentInput {
+	projectName: string;
+	branch: string;
+	repoId: number;
+	target?: VercelDeploymentTarget;
+}
+
+export function deployments(rest: RestClient) {
+	return {
+		trigger: (input: VercelTriggerDeploymentInput): Promise<VercelDeployment> =>
+			rest.request<VercelDeployment>("/v13/deployments", {
+				method: "POST",
+				body: {
+					name: input.projectName,
+					gitSource: { type: "github", ref: input.branch, repoId: input.repoId },
+					...(input.target ? { target: input.target } : {}),
+				},
+			}),
+
+		get: (deploymentId: string): Promise<VercelDeployment> =>
+			rest.request<VercelDeployment>(
+				`/v13/deployments/${encodeURIComponent(deploymentId)}`
+			),
+	};
+}

--- a/packages/vercel-client/src/deployments/deployments.ts
+++ b/packages/vercel-client/src/deployments/deployments.ts
@@ -27,19 +27,25 @@ export interface VercelTriggerDeploymentInput {
 
 export function deployments(rest: RestClient) {
 	return {
-		trigger: (input: VercelTriggerDeploymentInput): Promise<VercelDeployment> =>
+		trigger: (
+			input: VercelTriggerDeploymentInput,
+		): Promise<VercelDeployment> =>
 			rest.request<VercelDeployment>("/v13/deployments", {
 				method: "POST",
 				body: {
 					name: input.projectName,
-					gitSource: { type: "github", ref: input.branch, repoId: input.repoId },
+					gitSource: {
+						type: "github",
+						ref: input.branch,
+						repoId: input.repoId,
+					},
 					...(input.target ? { target: input.target } : {}),
 				},
 			}),
 
 		get: (deploymentId: string): Promise<VercelDeployment> =>
 			rest.request<VercelDeployment>(
-				`/v13/deployments/${encodeURIComponent(deploymentId)}`
+				`/v13/deployments/${encodeURIComponent(deploymentId)}`,
 			),
 	};
 }

--- a/packages/vercel-client/src/env/env.ts
+++ b/packages/vercel-client/src/env/env.ts
@@ -16,22 +16,27 @@ export function env(rest: RestClient) {
 	return {
 		list: (projectId: string): Promise<VercelEnvVarsResponse> =>
 			rest.request<VercelEnvVarsResponse>(
-				`/v9/projects/${encodeURIComponent(projectId)}/env`
+				`/v9/projects/${encodeURIComponent(projectId)}/env`,
 			),
 
 		set: (
 			projectId: string,
 			target: VercelEnvTarget,
 			name: string,
-			value: string
+			value: string,
 		): Promise<VercelEnvVar> =>
 			rest.request<VercelEnvVar>(
 				`/v10/projects/${encodeURIComponent(projectId)}/env`,
 				{
 					method: "POST",
 					query: { upsert: "true" },
-					body: { key: name, value, target: [target], type: "encrypted" },
-				}
+					body: {
+						key: name,
+						value,
+						target: [target],
+						type: "encrypted",
+					},
+				},
 			),
 	};
 }

--- a/packages/vercel-client/src/env/env.ts
+++ b/packages/vercel-client/src/env/env.ts
@@ -1,0 +1,37 @@
+import type { RestClient } from "../utils.js";
+
+export type VercelEnvTarget = "production" | "preview" | "development";
+
+export interface VercelEnvVar {
+	id: string;
+	key: string;
+	target: VercelEnvTarget[];
+}
+
+export interface VercelEnvVarsResponse {
+	envs: VercelEnvVar[];
+}
+
+export function env(rest: RestClient) {
+	return {
+		list: (projectId: string): Promise<VercelEnvVarsResponse> =>
+			rest.request<VercelEnvVarsResponse>(
+				`/v9/projects/${encodeURIComponent(projectId)}/env`
+			),
+
+		set: (
+			projectId: string,
+			target: VercelEnvTarget,
+			name: string,
+			value: string
+		): Promise<VercelEnvVar> =>
+			rest.request<VercelEnvVar>(
+				`/v10/projects/${encodeURIComponent(projectId)}/env`,
+				{
+					method: "POST",
+					query: { upsert: "true" },
+					body: { key: name, value, target: [target], type: "encrypted" },
+				}
+			),
+	};
+}

--- a/packages/vercel-client/src/index.ts
+++ b/packages/vercel-client/src/index.ts
@@ -1,0 +1,39 @@
+import { createVercelRestClient, type VercelClientOptions } from "./utils.js";
+import { deployments } from "./deployments/deployments.js";
+import { env } from "./env/env.js";
+import { projects } from "./projects/projects.js";
+import { user } from "./user/user.js";
+
+export type { VercelClientOptions } from "./utils.js";
+
+export type {
+	VercelDeployment,
+	VercelDeploymentState,
+	VercelDeploymentTarget,
+	VercelTriggerDeploymentInput,
+} from "./deployments/deployments.js";
+export type {
+	VercelEnvTarget,
+	VercelEnvVar,
+	VercelEnvVarsResponse,
+} from "./env/env.js";
+export type {
+	VercelProject,
+	VercelProjectLink,
+	VercelProjectsResponse,
+	VercelCreateProjectInput,
+	VercelUpdateProjectInput,
+} from "./projects/projects.js";
+export type { VercelUser, VercelUserResponse } from "./user/user.js";
+
+export function createVercelClient(opts: VercelClientOptions) {
+	const rest = createVercelRestClient(opts);
+	return {
+		deployments: deployments(rest),
+		env: env(rest),
+		projects: projects(rest),
+		user: user(rest),
+	};
+}
+
+export type VercelClient = ReturnType<typeof createVercelClient>;

--- a/packages/vercel-client/src/projects/projects.ts
+++ b/packages/vercel-client/src/projects/projects.ts
@@ -37,29 +37,44 @@ export function projects(rest: RestClient) {
 			rest.request<VercelProjectsResponse>("/v10/projects"),
 
 		get: (nameOrId: string): Promise<VercelProject> =>
-			rest.request<VercelProject>(`/v10/projects/${encodeURIComponent(nameOrId)}`),
+			rest.request<VercelProject>(
+				`/v10/projects/${encodeURIComponent(nameOrId)}`,
+			),
 
 		create: (input: VercelCreateProjectInput): Promise<VercelProject> => {
 			const body: Record<string, unknown> = {
 				name: input.name,
-				...(input.framework !== undefined ? { framework: input.framework } : {}),
-				...(input.repo ? { gitRepository: { type: "github", repo: input.repo } } : {}),
-				...(input.rootDirectory ? { rootDirectory: input.rootDirectory } : {}),
+				...(input.framework !== undefined
+					? { framework: input.framework }
+					: {}),
+				...(input.repo
+					? { gitRepository: { type: "github", repo: input.repo } }
+					: {}),
+				...(input.rootDirectory
+					? { rootDirectory: input.rootDirectory }
+					: {}),
 			};
-			return rest.request<VercelProject>("/v11/projects", { method: "POST", body });
+			return rest.request<VercelProject>("/v11/projects", {
+				method: "POST",
+				body,
+			});
 		},
 
-		update: (projectId: string, input: VercelUpdateProjectInput): Promise<VercelProject> => {
+		update: (
+			projectId: string,
+			input: VercelUpdateProjectInput,
+		): Promise<VercelProject> => {
 			const body: Record<string, unknown> = {};
 			if (input.previewDeploymentsDisabled !== undefined) {
-				body.previewDeploymentsDisabled = input.previewDeploymentsDisabled;
+				body.previewDeploymentsDisabled =
+					input.previewDeploymentsDisabled;
 			}
 			if (input.gitProviderOptions !== undefined) {
 				body.gitProviderOptions = input.gitProviderOptions;
 			}
 			return rest.request<VercelProject>(
 				`/v9/projects/${encodeURIComponent(projectId)}`,
-				{ method: "PATCH", body }
+				{ method: "PATCH", body },
 			);
 		},
 	};

--- a/packages/vercel-client/src/projects/projects.ts
+++ b/packages/vercel-client/src/projects/projects.ts
@@ -1,0 +1,66 @@
+import type { RestClient } from "../utils.js";
+
+export interface VercelProjectLink {
+	type?: string;
+	repoId?: number;
+	repo?: string;
+	org?: string;
+}
+
+export interface VercelProject {
+	id: string;
+	name: string;
+	framework?: string | null;
+	rootDirectory?: string | null;
+	link?: VercelProjectLink | null;
+}
+
+export interface VercelProjectsResponse {
+	projects: VercelProject[];
+}
+
+export interface VercelCreateProjectInput {
+	name: string;
+	framework?: string;
+	repo?: string;
+	rootDirectory?: string;
+}
+
+export interface VercelUpdateProjectInput {
+	previewDeploymentsDisabled?: boolean;
+	gitProviderOptions?: { createDeployments?: string };
+}
+
+export function projects(rest: RestClient) {
+	return {
+		list: (): Promise<VercelProjectsResponse> =>
+			rest.request<VercelProjectsResponse>("/v10/projects"),
+
+		get: (nameOrId: string): Promise<VercelProject> =>
+			rest.request<VercelProject>(`/v10/projects/${encodeURIComponent(nameOrId)}`),
+
+		create: (input: VercelCreateProjectInput): Promise<VercelProject> => {
+			const body: Record<string, unknown> = {
+				name: input.name,
+				...(input.framework !== undefined ? { framework: input.framework } : {}),
+				...(input.repo ? { gitRepository: { type: "github", repo: input.repo } } : {}),
+				...(input.rootDirectory ? { rootDirectory: input.rootDirectory } : {}),
+			};
+			return rest.request<VercelProject>("/v11/projects", { method: "POST", body });
+		},
+
+		update: (projectId: string, input: VercelUpdateProjectInput): Promise<VercelProject> => {
+			const body: Record<string, unknown> = {};
+			if (input.previewDeploymentsDisabled !== undefined) {
+				body.previewDeploymentsDisabled = input.previewDeploymentsDisabled;
+			}
+			if (input.gitProviderOptions !== undefined) {
+				body.gitProviderOptions = input.gitProviderOptions;
+			}
+			return rest.request<VercelProject>(
+				`/v9/projects/${encodeURIComponent(projectId)}`,
+				{ method: "PATCH", body }
+			);
+		},
+	};
+}

--- a/packages/vercel-client/src/user/user.ts
+++ b/packages/vercel-client/src/user/user.ts
@@ -13,6 +13,7 @@ export interface VercelUserResponse {
 
 export function user(rest: RestClient) {
 	return {
-		get: (): Promise<VercelUserResponse> => rest.request<VercelUserResponse>("/v2/user"),
+		get: (): Promise<VercelUserResponse> =>
+			rest.request<VercelUserResponse>("/v2/user"),
 	};
 }

--- a/packages/vercel-client/src/user/user.ts
+++ b/packages/vercel-client/src/user/user.ts
@@ -1,0 +1,18 @@
+import type { RestClient } from "../utils.js";
+
+export interface VercelUser {
+	id?: string;
+	username?: string;
+	email?: string;
+	name?: string;
+}
+
+export interface VercelUserResponse {
+	user?: VercelUser;
+}
+
+export function user(rest: RestClient) {
+	return {
+		get: (): Promise<VercelUserResponse> => rest.request<VercelUserResponse>("/v2/user"),
+	};
+}

--- a/packages/vercel-client/src/utils.ts
+++ b/packages/vercel-client/src/utils.ts
@@ -1,0 +1,24 @@
+import { createRestClient, type RestClient } from "@theholocron/http-client";
+
+export type { RestClient };
+
+export interface VercelClientOptions {
+	/** Vercel API token. */
+	token: string;
+	/** Team ID — appended as `?teamId=` on every request. Omit for personal accounts. */
+	teamId?: string;
+	/** Override base URL for testing. Defaults to https://api.vercel.com. */
+	baseUrl?: string;
+	/** Override fetch for testing. Defaults to globalThis.fetch. */
+	fetch?: typeof fetch;
+}
+
+export function createVercelRestClient(opts: VercelClientOptions): RestClient {
+	return createRestClient({
+		baseUrl: opts.baseUrl ?? "https://api.vercel.com",
+		token: opts.token,
+		defaultQuery: opts.teamId ? { teamId: opts.teamId } : undefined,
+		vendor: "Vercel",
+		fetch: opts.fetch,
+	});
+}

--- a/packages/vercel-client/tsconfig.json
+++ b/packages/vercel-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "display": "Vercel API Client",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "baseUrl": "./", "outDir": "./dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/vercel-client/tsdown.config.ts
+++ b/packages/vercel-client/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/vercel-client/vitest.config.ts
+++ b/packages/vercel-client/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,6 +603,52 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/vercel-client:
+    dependencies:
+      '@theholocron/http-client':
+        specifier: ^0.9.0
+        version: 0.9.0
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 7.0.0(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: 'catalog:'
+        version: 7.0.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.6.1)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/zendesk-client:
     dependencies:
       '@theholocron/http-client':
@@ -1373,6 +1419,10 @@ packages:
 
   '@theholocron/http-client@0.8.1':
     resolution: {integrity: sha512-V/wvtME8BjEM532kmASHOrta2c8l1rXsyavOWy9M+0QqrFZaEgrD1LDSB2TT4iuxpNdpeUR0d86b7ow7xgVOeg==}
+    engines: {node: '>=22.0.0'}
+
+  '@theholocron/http-client@0.9.0':
+    resolution: {integrity: sha512-eCT7JYzcI7qcvUu/1DzdmPcXAALZGMCZjPTrh7NxKMbmpKchH36dU/6oTSgCI8cFvPUudtRhhHOoGeC7IkUhUA==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@7.0.0':
@@ -4579,6 +4629,8 @@ snapshots:
   '@theholocron/http-client@0.7.0': {}
 
   '@theholocron/http-client@0.8.1': {}
+
+  '@theholocron/http-client@0.9.0': {}
 
   '@theholocron/lint-staged-config@7.0.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:

--- a/release.config.ts
+++ b/release.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/doppler-client','packages/github-client','packages/google-client','packages/http-client','packages/infisical-client','packages/jira-client','packages/neon-client','packages/postman-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/doppler-client','packages/github-client','packages/google-client','packages/http-client','packages/infisical-client','packages/jira-client','packages/neon-client','packages/postman-client','packages/vercel-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
## Summary

- Adds `@theholocron/vercel-client` — typed TypeScript client for the [Vercel REST API](https://vercel.com/docs/rest-api)
- 4 resource groups covering everything `holocron-plugin-vercel` uses:
  - **`user`** — `get()` → GET `/v2/user`
  - **`projects`** — `list()`, `get(nameOrId)`, `create(input)`, `update(id, input)`
  - **`env`** — `list(projectId)`, `set(projectId, target, name, value)` (upsert)
  - **`deployments`** — `trigger(input)`, `get(deploymentId)`
- `teamId` is wired via `defaultQuery` so it's automatically appended to every request — no per-call plumbing needed
- Registered in `release.config.ts` prepareCmd; version set to `0.9.0`
- 16 tests, all passing; typecheck + lint + build clean

## Test plan

- [x] `pnpm --filter @theholocron/vercel-client test` — 16 tests pass
- [x] `pnpm --filter @theholocron/vercel-client typecheck` — clean
- [x] `pnpm --filter @theholocron/vercel-client lint` — clean
- [x] `pnpm --filter @theholocron/vercel-client build` — dist emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->