### PR TITLE
fix(vercel-client): widen createDeployments type to boolean | string

### DIFF
--- a/.claude/skills/new-client.md
+++ b/.claude/skills/new-client.md
@@ -402,18 +402,37 @@ at the initial version while all other packages advance.
 ## 9. Update the consuming workspace
 
 If the new client will be consumed by `theholocron/holocron` (or
-another workspace), add it to that workspace's catalog and let the
-existing `overrides:` block handle deduplication:
+another workspace), add it to that workspace's catalog. Use the exact
+version from the latest git tag in the clients repo right before opening
+the migration PR (`git tag | sort -V | tail -1`), not the version set
+at branch creation — a release may have landed in between.
 
 ```yaml
 # pnpm-workspace.yaml in holocron
 catalog:
-  "@theholocron/<slug>-client": ^<version>
+  "@theholocron/<slug>-client": ^<X.Y.0>
 ```
 
-Then reference it as `catalog:` in the consuming `package.json`.
+Then reference it as `catalog:` in both `peerDependencies` and
+`devDependencies` of the consuming `package.json`:
+
+```json
+"peerDependencies": {
+  "@theholocron/<slug>-client": "catalog:"
+},
+"peerDependenciesMeta": {
+  "@theholocron/<slug>-client": { "optional": false }
+},
+"devDependencies": {
+  "@theholocron/<slug>-client": "catalog:"
+}
+```
+
 No additional `overrides:` entry is needed — the existing
 `@theholocron/http-client` override already covers the transitive dep.
+
+Then follow the plugin migration steps in
+`theholocron/holocron/.claude/skills/holocron-plugin.md` step 6.
 
 ---
 

--- a/packages/vercel-client/src/projects/projects.ts
+++ b/packages/vercel-client/src/projects/projects.ts
@@ -28,7 +28,7 @@ export interface VercelCreateProjectInput {
 
 export interface VercelUpdateProjectInput {
 	previewDeploymentsDisabled?: boolean;
-	gitProviderOptions?: { createDeployments?: string };
+	gitProviderOptions?: { createDeployments?: boolean | string };
 }
 
 export function projects(rest: RestClient) {


### PR DESCRIPTION
## Summary

`VercelUpdateProjectInput.gitProviderOptions.createDeployments` was typed as `string`
but the Vercel API accepts a boolean value and the consuming plugin (`holocron-plugin-vercel`)
passes `boolean`. Widen to `boolean | string`.

This removes the `as unknown as { createDeployments?: string }` cast that was added
as a workaround in `holocron-plugin-vercel/src/capabilities/deployment.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->