### PR TITLE
feat: add codecov.yml with per-package components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ scaffolding that are easy to miss:
    the package frozen at its initial version while all others advance.
 2. Set the initial `version` in `package.json` to match the current
    lockstep version (check the latest GitHub release tag).
+3. Add an entry to `codecov.yml` under `component_management.individual_components`
+   with `component_id: <slug>-client`, `name: "<slug>-client"`, and
+   `paths: [packages/<slug>-client/**]`.
+   (Will be automated by `holocron setup` once theholocron/holocron#168 ships.)
 
 ## Quality
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,61 +29,61 @@ component_management:
         target: 80%
   individual_components:
     - component_id: http-client
-      name: "@theholocron/http-client"
+      name: "http-client"
       paths:
         - packages/http-client/**
 
     - component_id: clerk-client
-      name: "@theholocron/clerk-client"
+      name: "clerk-client"
       paths:
         - packages/clerk-client/**
 
     - component_id: confluence-client
-      name: "@theholocron/confluence-client"
+      name: "confluence-client"
       paths:
         - packages/confluence-client/**
 
     - component_id: doppler-client
-      name: "@theholocron/doppler-client"
+      name: "doppler-client"
       paths:
         - packages/doppler-client/**
 
     - component_id: github-client
-      name: "@theholocron/github-client"
+      name: "github-client"
       paths:
         - packages/github-client/**
 
     - component_id: google-client
-      name: "@theholocron/google-client"
+      name: "google-client"
       paths:
         - packages/google-client/**
 
     - component_id: infisical-client
-      name: "@theholocron/infisical-client"
+      name: "infisical-client"
       paths:
         - packages/infisical-client/**
 
     - component_id: jira-client
-      name: "@theholocron/jira-client"
+      name: "jira-client"
       paths:
         - packages/jira-client/**
 
     - component_id: neon-client
-      name: "@theholocron/neon-client"
+      name: "neon-client"
       paths:
         - packages/neon-client/**
 
     - component_id: postman-client
-      name: "@theholocron/postman-client"
+      name: "postman-client"
       paths:
         - packages/postman-client/**
 
     - component_id: vercel-client
-      name: "@theholocron/vercel-client"
+      name: "vercel-client"
       paths:
         - packages/vercel-client/**
 
     - component_id: zendesk-client
-      name: "@theholocron/zendesk-client"
+      name: "zendesk-client"
       paths:
         - packages/zendesk-client/**

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,89 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        # Set to auto until coverage gaps in underserved packages are resolved (see #161).
+        # Long-term target matches the 80% threshold in @theholocron/vitest-config/bundles/library.
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+        threshold: 2%
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+  require_changes: true
+
+component_management:
+  default_rules:
+    statuses:
+      - type: patch
+        target: 80%
+  individual_components:
+    - component_id: http-client
+      name: "@theholocron/http-client"
+      paths:
+        - packages/http-client/**
+
+    - component_id: clerk-client
+      name: "@theholocron/clerk-client"
+      paths:
+        - packages/clerk-client/**
+
+    - component_id: confluence-client
+      name: "@theholocron/confluence-client"
+      paths:
+        - packages/confluence-client/**
+
+    - component_id: doppler-client
+      name: "@theholocron/doppler-client"
+      paths:
+        - packages/doppler-client/**
+
+    - component_id: github-client
+      name: "@theholocron/github-client"
+      paths:
+        - packages/github-client/**
+
+    - component_id: google-client
+      name: "@theholocron/google-client"
+      paths:
+        - packages/google-client/**
+
+    - component_id: infisical-client
+      name: "@theholocron/infisical-client"
+      paths:
+        - packages/infisical-client/**
+
+    - component_id: jira-client
+      name: "@theholocron/jira-client"
+      paths:
+        - packages/jira-client/**
+
+    - component_id: neon-client
+      name: "@theholocron/neon-client"
+      paths:
+        - packages/neon-client/**
+
+    - component_id: postman-client
+      name: "@theholocron/postman-client"
+      paths:
+        - packages/postman-client/**
+
+    - component_id: vercel-client
+      name: "@theholocron/vercel-client"
+      paths:
+        - packages/vercel-client/**
+
+    - component_id: zendesk-client
+      name: "@theholocron/zendesk-client"
+      paths:
+        - packages/zendesk-client/**


### PR DESCRIPTION
## Summary

Adds `codecov.yml` to configure Codecov for this monorepo. The reusable `test.yml` workflow already uploads coverage and test results to Codecov when `CODECOV_TOKEN` is set — this file tells Codecov how to interpret that data.

## What's configured

**Components** — 12 components, one per package, keyed by path (`packages/<slug>/**`). This means PR comments and the Codecov UI show coverage broken down per package rather than a single aggregate number.

**Project coverage** — `auto` for now. This tracks the trend without blocking PRs on a hard threshold. The rationale: some packages have known coverage gaps (see #161 — zendesk, jira, confluence, postman, vercel). Vitest already enforces 80% at the test level via `@theholocron/vitest-config/bundles/library`, so Codecov adding a second hard block feels premature until #161 is addressed. Plan to tighten to `target: 80%` once coverage is healthy across all packages.

**Patch coverage** — `80%` hard target. New code added in any PR must hit 80%, matching the vitest bundle threshold.

**PR comment layout** — `reach,diff,flags,components` — the components section shows the per-package breakdown inline in every PR.

## Automation

This file was written by hand. It will be auto-generated by `holocron setup` in the future — see theholocron/holocron#168.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->