### PR TITLE
chore: migrate holocron.config.ts to use theholocronNode() preset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ scaffolding that are easy to miss:
    the package frozen at its initial version while all others advance.
 2. Set the initial `version` in `package.json` to match the current
    lockstep version (check the latest GitHub release tag).
+3. Add an entry to `codecov.yml` under `component_management.individual_components`
+   with `component_id: <slug>-client`, `name: "<slug>-client"`, and
+   `paths: [packages/<slug>-client/**]`.
+   (Will be automated by `holocron setup` once theholocron/holocron#168 ships.)
 
 ## Quality
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,61 +29,61 @@ component_management:
         target: 80%
   individual_components:
     - component_id: http-client
-      name: "@theholocron/http-client"
+      name: "http-client"
       paths:
         - packages/http-client/**
 
     - component_id: clerk-client
-      name: "@theholocron/clerk-client"
+      name: "clerk-client"
       paths:
         - packages/clerk-client/**
 
     - component_id: confluence-client
-      name: "@theholocron/confluence-client"
+      name: "confluence-client"
       paths:
         - packages/confluence-client/**
 
     - component_id: doppler-client
-      name: "@theholocron/doppler-client"
+      name: "doppler-client"
       paths:
         - packages/doppler-client/**
 
     - component_id: github-client
-      name: "@theholocron/github-client"
+      name: "github-client"
       paths:
         - packages/github-client/**
 
     - component_id: google-client
-      name: "@theholocron/google-client"
+      name: "google-client"
       paths:
         - packages/google-client/**
 
     - component_id: infisical-client
-      name: "@theholocron/infisical-client"
+      name: "infisical-client"
       paths:
         - packages/infisical-client/**
 
     - component_id: jira-client
-      name: "@theholocron/jira-client"
+      name: "jira-client"
       paths:
         - packages/jira-client/**
 
     - component_id: neon-client
-      name: "@theholocron/neon-client"
+      name: "neon-client"
       paths:
         - packages/neon-client/**
 
     - component_id: postman-client
-      name: "@theholocron/postman-client"
+      name: "postman-client"
       paths:
         - packages/postman-client/**
 
     - component_id: vercel-client
-      name: "@theholocron/vercel-client"
+      name: "vercel-client"
       paths:
         - packages/vercel-client/**
 
     - component_id: zendesk-client
-      name: "@theholocron/zendesk-client"
+      name: "zendesk-client"
       paths:
         - packages/zendesk-client/**

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,89 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        # Set to auto until coverage gaps in underserved packages are resolved (see #161).
+        # Long-term target matches the 80% threshold in @theholocron/vitest-config/bundles/library.
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+        threshold: 2%
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+  require_changes: true
+
+component_management:
+  default_rules:
+    statuses:
+      - type: patch
+        target: 80%
+  individual_components:
+    - component_id: http-client
+      name: "@theholocron/http-client"
+      paths:
+        - packages/http-client/**
+
+    - component_id: clerk-client
+      name: "@theholocron/clerk-client"
+      paths:
+        - packages/clerk-client/**
+
+    - component_id: confluence-client
+      name: "@theholocron/confluence-client"
+      paths:
+        - packages/confluence-client/**
+
+    - component_id: doppler-client
+      name: "@theholocron/doppler-client"
+      paths:
+        - packages/doppler-client/**
+
+    - component_id: github-client
+      name: "@theholocron/github-client"
+      paths:
+        - packages/github-client/**
+
+    - component_id: google-client
+      name: "@theholocron/google-client"
+      paths:
+        - packages/google-client/**
+
+    - component_id: infisical-client
+      name: "@theholocron/infisical-client"
+      paths:
+        - packages/infisical-client/**
+
+    - component_id: jira-client
+      name: "@theholocron/jira-client"
+      paths:
+        - packages/jira-client/**
+
+    - component_id: neon-client
+      name: "@theholocron/neon-client"
+      paths:
+        - packages/neon-client/**
+
+    - component_id: postman-client
+      name: "@theholocron/postman-client"
+      paths:
+        - packages/postman-client/**
+
+    - component_id: vercel-client
+      name: "@theholocron/vercel-client"
+      paths:
+        - packages/vercel-client/**
+
+    - component_id: zendesk-client
+      name: "@theholocron/zendesk-client"
+      paths:
+        - packages/zendesk-client/**

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,60 +1,23 @@
 import { defineConfig } from "@theholocron/cli";
 import type { HolocronConfig } from "@theholocron/cli";
+import { theholocronNode } from "@theholocron/holocron-config";
 
+const defaults = theholocronNode();
 export default defineConfig({
 	project: {
 		name: "clients",
 		description:
 			"API clients and shared HTTP primitives for theholocron tooling.",
-		repo: {
-			name: "theholocron/clients",
-			protection: "strict",
-			topics: [
-				"api",
-				"api-client",
-				"client",
-				"confluence",
-				"google",
-				"http-client",
-				"jira",
-				"nodejs",
-				"rest",
-				"typescript",
-				"zendesk",
-			],
-			properties: {
-				lifecycle: "active",
-				open_source: true,
-				runtime_environment: "node",
-				uses_external_packages: true,
-			},
-		},
+		repo: "theholocron/clients",
+		repoPolicy: defaults.repoPolicy,
 		workflows: [
-			"lint",
-			"test",
-			"typecheck",
-			"codeql",
-			"review",
+			...defaults.workflows,
 			"audit",
 			{ name: "release", with: { "run-build": true } },
-			"dependencies",
-			"bookkeeping-pr",
-			"stale",
-			"greetings",
 		],
 	},
 	providers: {
-		source: "github",
-		ci: "github",
+		...defaults.providers,
 		secrets: "github",
-		issues: [
-			"github",
-			{
-				labels: {
-					inProgress: "status:in-progress",
-					inReview: "status:in-review",
-				},
-			},
-		],
 	},
 } satisfies HolocronConfig);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",
     "@theholocron/cli": "catalog:holocron",
+    "@theholocron/holocron-config": "catalog:holocron",
     "@theholocron/holocron-plugin-github": "catalog:holocron",
     "@commitlint/config-conventional": "^21.2.0",
     "@commitlint/types": "^21.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ catalogs:
     '@theholocron/cli':
       specifier: 2.0.0-alpha.36
       version: 2.0.0-alpha.36
+    '@theholocron/holocron-config':
+      specifier: ^7.2.0
+      version: 7.2.0
     '@theholocron/holocron-plugin-github':
       specifier: 2.0.0-alpha.36
       version: 2.0.0-alpha.36
@@ -97,6 +100,9 @@ importers:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
         version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/holocron-config':
+        specifier: catalog:holocron
+        version: 7.2.0(@theholocron/cli@2.0.0-alpha.36)
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
         version: 2.0.0-alpha.36(@theholocron/cli@2.0.0-alpha.36)
@@ -1421,6 +1427,12 @@ packages:
         optional: true
       eslint-plugin-storybook:
         optional: true
+
+  '@theholocron/holocron-config@7.2.0':
+    resolution: {integrity: sha512-eEQVNP5YGL1eA/ur8yjqbB4iq9khgL1jy2ZSR+8d7OSYjWMPe2osKL3GALF2qpaT9AjcVH9Enycy1kyDIviT9A==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@theholocron/cli': '>=2.0.0-alpha.1'
 
   '@theholocron/holocron-plugin-github@2.0.0-alpha.36':
     resolution: {integrity: sha512-78bPtIZ1JO3lmiykUjZLvbgiFPSq6c0v/EhLunuvqfU8X/f1DTBoYfzBDFdR6ALqOYuH9Xylyur/aEpgeIaKyg==}
@@ -4557,6 +4569,10 @@ snapshots:
     optionalDependencies:
       '@vitest/eslint-plugin': 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
+
+  '@theholocron/holocron-config@7.2.0(@theholocron/cli@2.0.0-alpha.36)':
+    dependencies:
+      '@theholocron/cli': 2.0.0-alpha.36
 
   '@theholocron/holocron-plugin-github@2.0.0-alpha.36(@theholocron/cli@2.0.0-alpha.36)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 catalogs:
   holocron:
     '@theholocron/cli': 2.0.0-alpha.36
+    '@theholocron/holocron-config': ^7.2.0
     '@theholocron/holocron-plugin-github': 2.0.0-alpha.36
 
 # Shared dep versions used across packages.


### PR DESCRIPTION
## Summary

- Migrates `holocron.config.ts` to import `theholocronNode()` from `@theholocron/holocron-config`
- Drops the copy-pasted providers block, strict repo policy, and baseline workflow list in favor of the shared preset
- Retains only what's unique: `project.name`, `project.description`, `project.repo`, the `audit` workflow, the `release` override, and `providers.secrets`

## Test plan

- [x] `pnpm install` resolves `@theholocron/holocron-config@7.2.0`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->