### PR TITLE
fix: migrate holocron.config.ts to node() preset with repo fragment

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 		description:
 			"API clients and shared HTTP primitives for theholocron tooling.",
 		repo: {
+			...repo,
 			name: "theholocron/clients",
 			topics: [
 				"api",
@@ -23,7 +24,6 @@ export default defineConfig({
 				"typescript",
 				"zendesk",
 			],
-			...repo,
 		},
 		workflows: [
 			...workflows,

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,23 +1,38 @@
 import { defineConfig } from "@theholocron/cli";
 import type { HolocronConfig } from "@theholocron/cli";
-import { theholocronNode } from "@theholocron/holocron-config";
+import { node } from "@theholocron/holocron-config";
 
-const defaults = theholocronNode();
+const { repo, workflows, providers } = node();
 export default defineConfig({
 	project: {
 		name: "clients",
 		description:
 			"API clients and shared HTTP primitives for theholocron tooling.",
-		repo: "theholocron/clients",
-		repoPolicy: defaults.repoPolicy,
+		repo: {
+			name: "theholocron/clients",
+			topics: [
+				"api",
+				"api-client",
+				"client",
+				"confluence",
+				"google",
+				"http-client",
+				"jira",
+				"nodejs",
+				"rest",
+				"typescript",
+				"zendesk",
+			],
+			...repo,
+		},
 		workflows: [
-			...defaults.workflows,
+			...workflows,
 			"audit",
 			{ name: "release", with: { "run-build": true } },
 		],
 	},
 	providers: {
-		...defaults.providers,
+		...providers,
 		secrets: "github",
 	},
 } satisfies HolocronConfig);


### PR DESCRIPTION
## Summary

- Replaces the stale `theholocronNode()` + `repoPolicy` approach with `node()` from `@theholocron/holocron-config@7.2.1`
- Destructures `{ repo, workflows, providers }` from `node()` for readability
- `repo` is now a proper `RepoConfig` object: `name` and `topics` inline, `...repo` spreads in `protection` and `properties` from the preset
- `providers` extends the preset defaults with `secrets: "github"`

## Test plan

- [x] `pnpm install` resolves `@theholocron/holocron-config@7.2.1`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->