### PR TITLE
fix: bump @theholocron/vitest-config to ^7.2.3 for coverage.enabled

### DIFF
--- a/packages/google-client/src/__tests__/key.test.ts
+++ b/packages/google-client/src/__tests__/key.test.ts
@@ -7,7 +7,7 @@ const REQUIRED = {
 	GOOGLE_PROJECT_ID: "my-project",
 	GOOGLE_PRIVATE_KEY_ID: "key-id-123",
 	GOOGLE_PRIVATE_KEY:
-		"-----BEGIN RSA PRIVATE KEY-----\\nMIIEowIB\\n-----END RSA PRIVATE KEY-----",
+		"-----BEGIN RSA PRIVATE KEY-----\\nMIIEowIB\\n-----END RSA PRIVATE KEY-----", // gitleaks:allow
 	GOOGLE_CLIENT_EMAIL: "svc@my-project.iam.gserviceaccount.com",
 	GOOGLE_CLIENT_ID: "123456789",
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^7.0.0
       version: 7.0.0
     '@theholocron/vitest-config':
-      specifier: ^7.2.2
-      version: 7.2.2
+      specifier: ^7.2.3
+      version: 7.2.3
     '@vitest/coverage-v8':
       specifier: ^4.1.10
       version: 4.1.10
@@ -166,7 +166,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -212,7 +212,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -258,7 +258,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -304,7 +304,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -359,7 +359,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/server-destroy':
         specifier: ^1.0.4
         version: 1.0.4
@@ -401,7 +401,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -447,7 +447,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -489,7 +489,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -535,7 +535,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -581,7 +581,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -627,7 +627,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -673,7 +673,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -1501,8 +1501,8 @@ packages:
     peerDependencies:
       tsdown: ^0
 
-  '@theholocron/vitest-config@7.2.2':
-    resolution: {integrity: sha512-i0mqgwd39VI9biBky169kU/HLTcmOUvbHwJ38irbiY0bsxOoRypidKGfCYtA9k3rEVt36AOFzcUzFz/tuq/OHw==}
+  '@theholocron/vitest-config@7.2.3':
+    resolution: {integrity: sha512-Esl4a2bpMPhYUfXq3LyuBeGUCrbuGoGz0Ol89IGFKE3Fz3kns4H6AW+cn+NmHjwSZfLHDxOy4e/aB+bkp/Fx5A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@storybook/addon-vitest': ^9
@@ -3245,8 +3245,8 @@ packages:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -4619,7 +4619,7 @@ snapshots:
     dependencies:
       tsdown: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
 
-  '@theholocron/vitest-config@7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+  '@theholocron/vitest-config@7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
@@ -6198,7 +6198,7 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
-  postcss@8.5.20:
+  postcss@8.5.19:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -6707,7 +6707,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.19
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@theholocron/prettier-config': ^7.0.0
   '@theholocron/tsconfig': ^7.0.0
   '@theholocron/tsdown-config': ^7.0.0
-  '@theholocron/vitest-config': ^7.2.2
+  '@theholocron/vitest-config': ^7.2.3
   '@vitest/eslint-plugin': ^1.6.23
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/vitest-config` to `^7.2.3`, which adds `coverage.enabled: true` to the `library()` bundle
- Root cause: `pnpm test -- --coverage` passes `-- --coverage` to each package's vitest subprocess; the `--` causes vitest to treat `--coverage` as a test file filter rather than a flag, so coverage was never collected
- `enabled: true` makes coverage run on every `vitest run` without needing the CLI flag

## Test plan

- [ ] Verify Codecov receives coverage reports on next CI run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->