### PR TITLE
test: add missing tests for branches, issues, user, and workflows in github-client

### DIFF
--- a/packages/github-client/src/__tests__/branches.test.ts
+++ b/packages/github-client/src/__tests__/branches.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+describe("branches", () => {
+	it("PUT /repos/{owner}/{name}/branches/{branch}/protection", async () => {
+		const { fetch, calls } = stubFetch([{ status: 200, body: {} }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const payload = { required_status_checks: null, enforce_admins: true };
+		await client.branches.protectBranch(REPO, "main", payload);
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain(
+			"/repos/theholocron/test-repo/branches/main/protection",
+		);
+		expect(calls[0]?.body).toMatchObject(payload);
+	});
+
+	it("encodes branch names with special characters", async () => {
+		const { fetch, calls } = stubFetch([{ status: 200, body: {} }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.branches.protectBranch(REPO, "feat/my-branch", {});
+		expect(calls[0]?.url).toContain("feat%2Fmy-branch");
+	});
+});

--- a/packages/github-client/src/__tests__/issues.test.ts
+++ b/packages/github-client/src/__tests__/issues.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+const RAW_ISSUE = {
+	id: 1,
+	number: 42,
+	title: "Test issue",
+	body: "body",
+	state: "open" as const,
+	labels: [{ name: "bug" }],
+	assignee: null,
+	updated_at: "2024-01-01T00:00:00Z",
+	html_url: "https://github.com/theholocron/test-repo/issues/42",
+};
+
+describe("issues", () => {
+	it("GET /repos/{owner}/{name}/issues — no params", async () => {
+		const { fetch, calls } = stubFetch([{ body: [RAW_ISSUE] }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.issues.listIssues(REPO);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/repos/theholocron/test-repo/issues");
+		expect(calls[0]?.url).not.toContain("?");
+		expect(result).toEqual([RAW_ISSUE]);
+	});
+
+	it("GET /repos/{owner}/{name}/issues — with params", async () => {
+		const { fetch, calls } = stubFetch([{ body: [RAW_ISSUE] }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.listIssues(REPO, {
+			state: "open",
+			sort: "updated",
+			direction: "desc",
+			per_page: 50,
+			filter: "assigned",
+			assignee: "octocat",
+		});
+		expect(calls[0]?.url).toContain("state=open");
+		expect(calls[0]?.url).toContain("sort=updated");
+		expect(calls[0]?.url).toContain("direction=desc");
+		expect(calls[0]?.url).toContain("per_page=50");
+		expect(calls[0]?.url).toContain("filter=assigned");
+		expect(calls[0]?.url).toContain("assignee=octocat");
+	});
+
+	it("GET /repos/{owner}/{name}/issues/{number}", async () => {
+		const { fetch, calls } = stubFetch([{ body: RAW_ISSUE }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.issues.getIssue(REPO, 42);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/issues/42");
+		expect(result).toEqual(RAW_ISSUE);
+	});
+
+	it("POST /repos/{owner}/{name}/issues", async () => {
+		const { fetch, calls } = stubFetch([{ body: RAW_ISSUE }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.createIssue(REPO, { title: "Test issue" });
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/issues");
+		expect(calls[0]?.body).toMatchObject({ title: "Test issue" });
+	});
+
+	it("PATCH /repos/{owner}/{name}/issues/{number}", async () => {
+		const { fetch, calls } = stubFetch([{ body: RAW_ISSUE }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.updateIssue(REPO, 42, { state: "closed" });
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toContain("/issues/42");
+		expect(calls[0]?.body).toMatchObject({ state: "closed" });
+	});
+
+	it("POST /repos/{owner}/{name}/issues/{number}/labels", async () => {
+		const { fetch, calls } = stubFetch([{ status: 200, body: [] }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.addLabels(REPO, 42, ["bug", "help wanted"]);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/issues/42/labels");
+		expect(calls[0]?.body).toMatchObject({ labels: ["bug", "help wanted"] });
+	});
+
+	it("DELETE /repos/{owner}/{name}/issues/{number}/labels/{name}", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.removeLabel(REPO, 42, "bug");
+		expect(calls[0]?.method).toBe("DELETE");
+		expect(calls[0]?.url).toContain("/issues/42/labels/bug");
+	});
+
+	it("POST /repos/{owner}/{name}/issues/{number}/comments", async () => {
+		const { fetch, calls } = stubFetch([{ status: 201, body: {} }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.createComment(REPO, 42, "Hello!");
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain("/issues/42/comments");
+		expect(calls[0]?.body).toMatchObject({ body: "Hello!" });
+	});
+
+	it("GET /repos/{owner}/{name}/milestones — defaults to per_page=100", async () => {
+		const { fetch, calls } = stubFetch([{ body: [] }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.listMilestones(REPO);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/milestones");
+		expect(calls[0]?.url).toContain("per_page=100");
+	});
+
+	it("GET /repos/{owner}/{name}/milestones — with state param", async () => {
+		const { fetch, calls } = stubFetch([{ body: [] }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.issues.listMilestones(REPO, { state: "closed" });
+		expect(calls[0]?.url).toContain("state=closed");
+	});
+});

--- a/packages/github-client/src/__tests__/issues.test.ts
+++ b/packages/github-client/src/__tests__/issues.test.ts
@@ -77,7 +77,9 @@ describe("issues", () => {
 		await client.issues.addLabels(REPO, 42, ["bug", "help wanted"]);
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toContain("/issues/42/labels");
-		expect(calls[0]?.body).toMatchObject({ labels: ["bug", "help wanted"] });
+		expect(calls[0]?.body).toMatchObject({
+			labels: ["bug", "help wanted"],
+		});
 	});
 
 	it("DELETE /repos/{owner}/{name}/issues/{number}/labels/{name}", async () => {

--- a/packages/github-client/src/__tests__/user.test.ts
+++ b/packages/github-client/src/__tests__/user.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN } from "./helpers.js";
+
+describe("user", () => {
+	it("GET /user", async () => {
+		const body = { login: "octocat", name: "Octocat", email: null };
+		const { fetch, calls } = stubFetch([{ body }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.user.getCurrentUser();
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/user");
+		expect(result).toEqual(body);
+	});
+});

--- a/packages/github-client/src/__tests__/workflows.test.ts
+++ b/packages/github-client/src/__tests__/workflows.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+const RAW_RUN = {
+	id: 1,
+	name: "CI",
+	display_title: "chore: update deps",
+	head_branch: "main",
+	head_sha: "abc123",
+	status: "completed",
+	conclusion: "success",
+	html_url: "https://github.com/theholocron/test-repo/actions/runs/1",
+	created_at: "2024-01-01T00:00:00Z",
+	updated_at: "2024-01-01T01:00:00Z",
+};
+
+describe("workflows", () => {
+	it("GET /repos/{owner}/{name}/actions/runs — no filter", async () => {
+		const { fetch, calls } = stubFetch([
+			{ body: { total_count: 1, workflow_runs: [RAW_RUN] } },
+		]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.workflows.listRuns(REPO);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain(
+			"/repos/theholocron/test-repo/actions/runs",
+		);
+		expect(calls[0]?.url).not.toContain("?");
+		expect(result).toEqual([RAW_RUN]);
+	});
+
+	it("GET /repos/{owner}/{name}/actions/runs — with filter", async () => {
+		const { fetch, calls } = stubFetch([
+			{ body: { total_count: 1, workflow_runs: [RAW_RUN] } },
+		]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.workflows.listRuns(REPO, {
+			branch: "main",
+			limit: 10,
+			status: "completed",
+		});
+		expect(calls[0]?.url).toContain("branch=main");
+		expect(calls[0]?.url).toContain("per_page=10");
+		expect(calls[0]?.url).toContain("status=completed");
+	});
+
+	it("GET /repos/{owner}/{name}/actions/runs/{id}", async () => {
+		const { fetch, calls } = stubFetch([{ body: RAW_RUN }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.workflows.getRun(REPO, 1);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain("/actions/runs/1");
+		expect(result).toEqual(RAW_RUN);
+	});
+});


### PR DESCRIPTION
## Summary

Adds tests for the four `github-client` modules that had no coverage at all, bringing the package from ~60% to 99% statement coverage and 97% branch coverage — well above the 80% threshold in the `library()` vitest bundle.

| Module | Tests added |
|---|---|
| `branches` | `protectBranch` + branch-name encoding |
| `issues` | `listIssues` (with/without params), `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones` (with/without state) |
| `user` | `getCurrentUser` |
| `workflows` | `listRuns` (with/without filter), `getRun` |

## Test plan

- [x] `pnpm --filter @theholocron/github-client test` — 99% stmts, 97% branches, all pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->