### PR TITLE
test: bring all packages to 80% coverage threshold

### DIFF
--- a/packages/google-client/src/__tests__/authentication.test.ts
+++ b/packages/google-client/src/__tests__/authentication.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── googleapis mock ──────────────────────────────────────────────────────────
+
+const mockGetToken = vi.fn();
+const mockGenerateAuthUrl = vi.fn().mockReturnValue("https://accounts.google.com/o/oauth2/auth");
+const mockGetClient = vi.fn().mockResolvedValue({ type: "JWT" });
+
+class MockOAuth2 {
+	generateAuthUrl = mockGenerateAuthUrl;
+	getToken = mockGetToken;
+	credentials: Record<string, unknown> = {};
+}
+
+class MockGoogleAuth {
+	getClient = mockGetClient;
+}
+
+vi.mock("googleapis", () => ({
+	google: {
+		auth: { GoogleAuth: MockGoogleAuth, OAuth2: MockOAuth2 },
+	},
+}));
+
+vi.mock("../key.js", () => ({
+	loadServiceAccountKey: vi.fn().mockReturnValue({ type: "service_account" }),
+}));
+
+// ── node:http mock ────────────────────────────────────────────────────────────
+
+type Handler = (req: { url: string }, res: { end: (s: string) => void }) => void;
+
+let capturedHandler: Handler | null = null;
+const mockServer = {
+	listen: vi.fn().mockImplementation((_port: number, cb?: () => void) => {
+		cb?.();
+		return mockServer;
+	}),
+	destroy: vi.fn(),
+};
+
+vi.mock("node:http", () => ({
+	default: {
+		createServer: vi.fn().mockImplementation((handler: Handler) => {
+			capturedHandler = handler;
+			return mockServer;
+		}),
+	},
+}));
+
+vi.mock("server-destroy", () => ({
+	default: vi.fn(),
+}));
+
+vi.mock("open", () => ({
+	default: vi.fn().mockResolvedValue({ unref: vi.fn() }),
+}));
+
+// ── dynamic imports (after vi.mock) ───────────────────────────────────────────
+
+const { googleAuth, oauth } = await import("../authentication.js");
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("googleAuth", () => {
+	it("returns a client from GoogleAuth.getClient", async () => {
+		const client = await googleAuth([
+			"https://www.googleapis.com/auth/spreadsheets.readonly",
+		]);
+		expect(client).toMatchObject({ type: "JWT" });
+	});
+
+	it("accepts multiple scopes", async () => {
+		const client = await googleAuth([
+			"https://www.googleapis.com/auth/spreadsheets.readonly",
+			"https://www.googleapis.com/auth/documents.readonly",
+		]);
+		expect(client).toBeDefined();
+	});
+});
+
+describe("oauth", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGenerateAuthUrl.mockReturnValue("https://accounts.google.com/o/oauth2/auth");
+		mockGetClient.mockResolvedValue({ type: "JWT" });
+		mockServer.listen.mockImplementation((_port: number, cb?: () => void) => {
+			cb?.();
+			return mockServer;
+		});
+		capturedHandler = null;
+	});
+
+	afterEach(() => {
+		delete process.env["GOOGLE_CLIENT_ID"];
+		delete process.env["GOOGLE_CLIENT_SECRET"];
+	});
+
+	it("rejects when GOOGLE_CLIENT_ID is missing", async () => {
+		process.env["GOOGLE_CLIENT_SECRET"] = "secret";
+		await expect(oauth(["scope"])).rejects.toThrow("GOOGLE_CLIENT_ID");
+	});
+
+	it("rejects when GOOGLE_CLIENT_SECRET is missing", async () => {
+		process.env["GOOGLE_CLIENT_ID"] = "client-id";
+		await expect(oauth(["scope"])).rejects.toThrow("GOOGLE_CLIENT_SECRET");
+	});
+
+	it("resolves with the OAuth2 client after a successful callback", async () => {
+		process.env["GOOGLE_CLIENT_ID"] = "client-id";
+		process.env["GOOGLE_CLIENT_SECRET"] = "client-secret";
+		mockGetToken.mockResolvedValue({ tokens: { access_token: "tok" } });
+
+		const promise = oauth(["https://www.googleapis.com/auth/drive"]);
+
+		// Simulate the browser redirecting back to /oauth2callback
+		await new Promise<void>((r) => setImmediate(r));
+		expect(capturedHandler).not.toBeNull();
+		await capturedHandler!(
+			{ url: "/oauth2callback?code=test-code" },
+			{ end: vi.fn() },
+		);
+
+		const result = await promise;
+		expect(result).toBeDefined();
+	});
+
+	it("rejects when getToken throws inside the callback", async () => {
+		process.env["GOOGLE_CLIENT_ID"] = "client-id";
+		process.env["GOOGLE_CLIENT_SECRET"] = "client-secret";
+		mockGetToken.mockRejectedValue(new Error("token exchange failed"));
+
+		const promise = oauth(["scope"]);
+
+		await new Promise<void>((r) => setImmediate(r));
+		expect(capturedHandler).not.toBeNull();
+		await capturedHandler!(
+			{ url: "/oauth2callback?code=bad-code" },
+			{ end: vi.fn() },
+		);
+
+		await expect(promise).rejects.toThrow("token exchange failed");
+	});
+
+	it("ignores requests that are not /oauth2callback", async () => {
+		process.env["GOOGLE_CLIENT_ID"] = "client-id";
+		process.env["GOOGLE_CLIENT_SECRET"] = "client-secret";
+		mockGetToken.mockResolvedValue({ tokens: { access_token: "tok" } });
+
+		const promise = oauth(["scope"]);
+
+		await new Promise<void>((r) => setImmediate(r));
+		// Unrelated path — should be ignored
+		await capturedHandler!({ url: "/healthz" }, { end: vi.fn() });
+		// Now send the real callback
+		await capturedHandler!({ url: "/oauth2callback?code=abc" }, { end: vi.fn() });
+
+		await expect(promise).resolves.toBeDefined();
+	});
+});

--- a/packages/google-client/src/__tests__/authentication.test.ts
+++ b/packages/google-client/src/__tests__/authentication.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // ── googleapis mock ──────────────────────────────────────────────────────────
 
 const mockGetToken = vi.fn();
-const mockGenerateAuthUrl = vi.fn().mockReturnValue("https://accounts.google.com/o/oauth2/auth");
+const mockGenerateAuthUrl = vi
+	.fn()
+	.mockReturnValue("https://accounts.google.com/o/oauth2/auth");
 const mockGetClient = vi.fn().mockResolvedValue({ type: "JWT" });
 
 class MockOAuth2 {
@@ -28,7 +30,10 @@ vi.mock("../key.js", () => ({
 
 // ── node:http mock ────────────────────────────────────────────────────────────
 
-type Handler = (req: { url: string }, res: { end: (s: string) => void }) => void;
+type Handler = (
+	req: { url: string },
+	res: { end: (s: string) => void },
+) => void;
 
 let capturedHandler: Handler | null = null;
 const mockServer = {
@@ -82,12 +87,16 @@ describe("googleAuth", () => {
 describe("oauth", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockGenerateAuthUrl.mockReturnValue("https://accounts.google.com/o/oauth2/auth");
+		mockGenerateAuthUrl.mockReturnValue(
+			"https://accounts.google.com/o/oauth2/auth",
+		);
 		mockGetClient.mockResolvedValue({ type: "JWT" });
-		mockServer.listen.mockImplementation((_port: number, cb?: () => void) => {
-			cb?.();
-			return mockServer;
-		});
+		mockServer.listen.mockImplementation(
+			(_port: number, cb?: () => void) => {
+				cb?.();
+				return mockServer;
+			},
+		);
 		capturedHandler = null;
 	});
 
@@ -153,7 +162,10 @@ describe("oauth", () => {
 		// Unrelated path — should be ignored
 		await capturedHandler!({ url: "/healthz" }, { end: vi.fn() });
 		// Now send the real callback
-		await capturedHandler!({ url: "/oauth2callback?code=abc" }, { end: vi.fn() });
+		await capturedHandler!(
+			{ url: "/oauth2callback?code=abc" },
+			{ end: vi.fn() },
+		);
 
 		await expect(promise).resolves.toBeDefined();
 	});

--- a/packages/http-client/src/__tests__/auth-resolver.test.ts
+++ b/packages/http-client/src/__tests__/auth-resolver.test.ts
@@ -68,4 +68,39 @@ describe("createResolveToken", () => {
 		expect(err).toBeInstanceOf(AuthError);
 		expect((err as Error).name).toBe("AuthError");
 	});
+
+	it("falls back to process.env when env is not provided", () => {
+		process.env["HOLOCRON_TEST_TOKEN"] = "from-process-env";
+		try {
+			expect(resolveToken({ keyring: noKeyring })).toBe("from-process-env");
+		} finally {
+			delete process.env["HOLOCRON_TEST_TOKEN"];
+		}
+	});
+
+	it("falls back to defaultKeyring when keyring is not provided", () => {
+		// defaultKeyring = () => null, so it falls through to throwing
+		const err = (() => {
+			try {
+				resolveToken({ env: {} });
+			} catch (e) {
+				return e;
+			}
+		})();
+		expect(err).toBeInstanceOf(AuthError);
+	});
+});
+
+describe("createResolveToken — with getKeyringToken", () => {
+	it("uses getKeyringToken from config as the default keyring", () => {
+		const configKeyring = (p: string) => (p === "test" ? "from-config-kr" : null);
+		const resolver = createResolveToken({
+			envName: "HOLOCRON_TEST_TOKEN",
+			vendorEnvName: "TEST_TOKEN",
+			keyringService: "test",
+			errorMessage: "no token",
+			getKeyringToken: configKeyring,
+		});
+		expect(resolver({ env: {} })).toBe("from-config-kr");
+	});
 });

--- a/packages/http-client/src/__tests__/auth-resolver.test.ts
+++ b/packages/http-client/src/__tests__/auth-resolver.test.ts
@@ -72,7 +72,9 @@ describe("createResolveToken", () => {
 	it("falls back to process.env when env is not provided", () => {
 		process.env["HOLOCRON_TEST_TOKEN"] = "from-process-env";
 		try {
-			expect(resolveToken({ keyring: noKeyring })).toBe("from-process-env");
+			expect(resolveToken({ keyring: noKeyring })).toBe(
+				"from-process-env",
+			);
 		} finally {
 			delete process.env["HOLOCRON_TEST_TOKEN"];
 		}
@@ -93,7 +95,8 @@ describe("createResolveToken", () => {
 
 describe("createResolveToken — with getKeyringToken", () => {
 	it("uses getKeyringToken from config as the default keyring", () => {
-		const configKeyring = (p: string) => (p === "test" ? "from-config-kr" : null);
+		const configKeyring = (p: string) =>
+			p === "test" ? "from-config-kr" : null;
 		const resolver = createResolveToken({
 			envName: "HOLOCRON_TEST_TOKEN",
 			vendorEnvName: "TEST_TOKEN",

--- a/packages/http-client/src/__tests__/rest-client.test.ts
+++ b/packages/http-client/src/__tests__/rest-client.test.ts
@@ -174,3 +174,72 @@ describe("createRestClient — error handling", () => {
 		expect(calls[0]?.url).toBe("https://api.example.com/foo");
 	});
 });
+
+describe("createRestClient — path without leading slash", () => {
+	it("prepends slash to path that doesn't start with /", async () => {
+		const { fetch, calls } = stubFetch([{ body: {} }]);
+		await createRestClient({
+			baseUrl: "https://api.example.com",
+			token: TOKEN,
+			fetch,
+		}).request("no-slash");
+		expect(calls[0]?.url).toBe("https://api.example.com/no-slash");
+	});
+});
+
+describe("createRestClient — per-request query params", () => {
+	it("merges opts.query with defaultQuery", async () => {
+		const { fetch, calls } = stubFetch([{ body: {} }]);
+		await createRestClient({
+			baseUrl: "https://api.example.com",
+			token: TOKEN,
+			defaultQuery: { global: "1" },
+			fetch,
+		}).request("/path", { query: { local: "2" } });
+		expect(calls[0]?.url).toContain("global=1");
+		expect(calls[0]?.url).toContain("local=2");
+	});
+});
+
+describe("createRestClient — empty body response", () => {
+	it("returns undefined for 200 with empty text body", async () => {
+		const { fetch } = stubFetch([{ text: "" }]);
+		const result = await createRestClient({
+			baseUrl: "https://api.example.com",
+			token: TOKEN,
+			fetch,
+		}).request("/empty");
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("createRestClient — non-Error thrown by fetch", () => {
+	it("wraps a string thrown by fetch as ProviderApiError", async () => {
+		const fetch = vi.fn(async () => {
+			// eslint-disable-next-line @typescript-eslint/only-throw-error
+			throw "network gone";
+		}) as unknown as typeof globalThis.fetch;
+		const err = await createRestClient({
+			baseUrl: "https://api.example.com",
+			token: TOKEN,
+			fetch,
+		})
+			.request("/ping")
+			.catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(ProviderApiError);
+		expect((err as ProviderApiError).message).toContain("network gone");
+	});
+});
+
+describe("createRestClient — apikey with default header name", () => {
+	it("uses x-api-key when apiKeyHeader is not specified", async () => {
+		const { fetch, calls } = stubFetch([{ body: {} }]);
+		await createRestClient({
+			baseUrl: "https://api.example.com",
+			token: TOKEN,
+			tokenScheme: "apikey",
+			fetch,
+		}).request("/ping");
+		expect(calls[0]?.headers["x-api-key"]).toBe(TOKEN);
+	});
+});

--- a/packages/postman-client/src/__tests__/resources.test.ts
+++ b/packages/postman-client/src/__tests__/resources.test.ts
@@ -202,4 +202,13 @@ describe("import.openapi", () => {
 		expect(calls[0]?.body).toMatchObject({ type: "string" });
 		expect(result.collections[0]?.name).toBe("Imported");
 	});
+
+	it("passes a string spec through without JSON-encoding it", async () => {
+		const { client, calls } = makeClient([
+			{ status: 200, body: { collections: [] } },
+		]);
+		const raw = '{"openapi":"3.1.0"}';
+		await client.import.openapi("ws2", raw);
+		expect(calls[0]?.body).toMatchObject({ input: raw });
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^7.0.0
       version: 7.0.0
     '@theholocron/vitest-config':
-      specifier: ^7.2.2
-      version: 7.2.2
+      specifier: ^7.2.3
+      version: 7.2.3
     '@vitest/coverage-v8':
       specifier: ^4.1.10
       version: 4.1.10
@@ -166,7 +166,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -212,7 +212,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -258,7 +258,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -304,7 +304,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -359,7 +359,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/server-destroy':
         specifier: ^1.0.4
         version: 1.0.4
@@ -401,7 +401,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -447,7 +447,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -489,7 +489,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -535,7 +535,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -581,7 +581,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -627,7 +627,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -673,7 +673,7 @@ importers:
         version: 7.0.0(tsdown@0.22.8(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -1501,8 +1501,8 @@ packages:
     peerDependencies:
       tsdown: ^0
 
-  '@theholocron/vitest-config@7.2.2':
-    resolution: {integrity: sha512-i0mqgwd39VI9biBky169kU/HLTcmOUvbHwJ38irbiY0bsxOoRypidKGfCYtA9k3rEVt36AOFzcUzFz/tuq/OHw==}
+  '@theholocron/vitest-config@7.2.3':
+    resolution: {integrity: sha512-Esl4a2bpMPhYUfXq3LyuBeGUCrbuGoGz0Ol89IGFKE3Fz3kns4H6AW+cn+NmHjwSZfLHDxOy4e/aB+bkp/Fx5A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@storybook/addon-vitest': ^9
@@ -4619,7 +4619,7 @@ snapshots:
     dependencies:
       tsdown: 0.22.8(tsx@4.23.1)(typescript@5.9.3)
 
-  '@theholocron/vitest-config@7.2.2(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+  '@theholocron/vitest-config@7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@theholocron/prettier-config': ^7.0.0
   '@theholocron/tsconfig': ^7.0.0
   '@theholocron/tsdown-config': ^7.0.0
-  '@theholocron/vitest-config': ^7.2.2
+  '@theholocron/vitest-config': ^7.2.3
   '@vitest/eslint-plugin': ^1.6.23
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2


### PR DESCRIPTION
## Summary

Adds tests to bring the three packages that were failing the 80% coverage threshold above the bar. Also includes the `^7.2.3` vitest-config bump (with `coverage.enabled: true`) needed for coverage to run at all.

| Package | Before | After |
|---|---|---|
| `http-client` | 71% funcs, 79% branches | 85% funcs, 95% branches |
| `google-client` | 30% funcs, 36% branches | 100% funcs, 95% branches |
| `postman-client` | 75% branches | 81% branches |

**http-client** — added tests for: `process.env` fallback, `defaultKeyring` fallback, `getKeyringToken` in config, path without leading `/`, per-request `query` params, empty-body 200 response, non-Error thrown by fetch, `apikey` scheme without explicit header name.

**google-client** — added `authentication.test.ts`: mocks `node:http`, `server-destroy`, `open`, and `googleapis` to fully simulate the OAuth callback flow, including the success path, token exchange error, and non-callback request being ignored.

**postman-client** — added test for `import.openapi` with a pre-serialized string spec (the object branch was already covered; the string branch was missing).

## Test plan

- [x] `pnpm --filter @theholocron/http-client test` — 94%/95%/85% ✓
- [x] `pnpm --filter @theholocron/google-client test` — 100%/95%/100% ✓
- [x] `pnpm --filter @theholocron/postman-client test` — 94%/81%/100% ✓
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->