### PR TITLE
chore: flatten holocron.config — promote project fields to root

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -5,7 +5,8 @@ import { node } from "@theholocron/holocron-config";
 const { repo, workflows, providers } = node();
 export default defineConfig({
 	name: "clients",
-	description: "API clients and shared HTTP primitives for theholocron tooling.",
+	description:
+		"API clients and shared HTTP primitives for theholocron tooling.",
 	repo: {
 		...repo,
 		name: "theholocron/clients",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -4,33 +4,30 @@ import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();
 export default defineConfig({
-	project: {
-		name: "clients",
-		description:
-			"API clients and shared HTTP primitives for theholocron tooling.",
-		repo: {
-			...repo,
-			name: "theholocron/clients",
-			topics: [
-				"api",
-				"api-client",
-				"client",
-				"confluence",
-				"google",
-				"http-client",
-				"jira",
-				"nodejs",
-				"rest",
-				"typescript",
-				"zendesk",
-			],
-		},
-		workflows: [
-			...workflows,
-			"audit",
-			{ name: "release", with: { "run-build": true } },
+	name: "clients",
+	description: "API clients and shared HTTP primitives for theholocron tooling.",
+	repo: {
+		...repo,
+		name: "theholocron/clients",
+		topics: [
+			"api",
+			"api-client",
+			"client",
+			"confluence",
+			"google",
+			"http-client",
+			"jira",
+			"nodejs",
+			"rest",
+			"typescript",
+			"zendesk",
 		],
 	},
+	workflows: [
+		...workflows,
+		"audit",
+		{ name: "release", with: { "run-build": true } },
+	],
 	providers: {
 		...providers,
 		secrets: "github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,14 +56,14 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.36
-      version: 2.0.0-alpha.36
+      specifier: 2.0.0-alpha.56
+      version: 2.0.0-alpha.56
     '@theholocron/holocron-config':
-      specifier: ^7.2.0
-      version: 7.2.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.36
-      version: 2.0.0-alpha.36
+      specifier: 2.0.0-alpha.56
+      version: 2.0.0-alpha.56
 
 overrides:
   '@commitlint/config-conventional': ^21.2.0
@@ -93,7 +93,7 @@ importers:
         version: 10.0.1(semantic-release@25.0.7(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.36
+        version: 2.0.0-alpha.56
       '@theholocron/commitlint-config':
         specifier: 'catalog:'
         version: 7.0.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)
@@ -102,10 +102,10 @@ importers:
         version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:holocron
-        version: 7.2.0(@theholocron/cli@2.0.0-alpha.36)
+        version: 7.3.0(@theholocron/cli@2.0.0-alpha.56)
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.36(@theholocron/cli@2.0.0-alpha.36)
+        version: 2.0.0-alpha.56(@theholocron/cli@2.0.0-alpha.56)(@theholocron/github-client@0.11.3)
       '@theholocron/lint-staged-config':
         specifier: 'catalog:'
         version: 7.0.0(husky@9.1.7)(lint-staged@16.4.0)
@@ -1391,8 +1391,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/cli@2.0.0-alpha.36':
-    resolution: {integrity: sha512-up/NEAKdbhnYGdJ4m8w4BT4ou7qjSFeJJHXaXBD5Mcj2uxeARVHSc5VsgSQRZXZRMyzkRs0Dd2Uqa2O0iEblwQ==}
+  '@theholocron/cli@2.0.0-alpha.56':
+    resolution: {integrity: sha512-bu23IZqVhhzpvfX7ogCFmcq+QeeMj1DgEYhAZoSeB7WguKzTAFZaeF9yWU5mMiRXP+1byqB4lS/nvl19GcChMg==}
     hasBin: true
 
   '@theholocron/commitlint-config@7.0.0':
@@ -1428,19 +1428,25 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/holocron-config@7.2.0':
-    resolution: {integrity: sha512-eEQVNP5YGL1eA/ur8yjqbB4iq9khgL1jy2ZSR+8d7OSYjWMPe2osKL3GALF2qpaT9AjcVH9Enycy1kyDIviT9A==}
+  '@theholocron/github-client@0.11.3':
+    resolution: {integrity: sha512-5XilkR1+0L0sE6/KGs2rGGvCPySKnYu0hRJ3vf6YRf1sz1kA2YPy9/zeZTArG0PVtF4GQWGZQ0DQCUvOWZAc6g==}
+    engines: {node: '>=22.0.0'}
+
+  '@theholocron/holocron-config@7.3.0':
+    resolution: {integrity: sha512-Ptjs8yxR8aDInHUUAQkBvsiRsVtKMBvbnuqkZqwZPtvJ7x747Ew2dD8nZtflEDmnmBVEhIab7PEjdlAONavJIA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.36':
-    resolution: {integrity: sha512-78bPtIZ1JO3lmiykUjZLvbgiFPSq6c0v/EhLunuvqfU8X/f1DTBoYfzBDFdR6ALqOYuH9Xylyur/aEpgeIaKyg==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.56':
+    resolution: {integrity: sha512-N3gKA1WOGWPWHmTe40c4JKal9OP6AIf3xxNDBiWhbVZCZ+M2ulxFl1I9KaXU9EMggopAFNNkVcvL8RrrZuHzxg==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.36
+      '@theholocron/cli': 2.0.0-alpha.56
+      '@theholocron/github-client': ^0.11.3
 
-  '@theholocron/http-client@0.1.0':
-    resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
+  '@theholocron/http-client@0.11.3':
+    resolution: {integrity: sha512-eayCX5Na1tWRMYLeQdl1aA4IfbFrIbAC8nvbbc4QzlV/BeoVjZik0FK5jz3WAQZP9McEC1Y5nR4pFImXtxG1JA==}
+    engines: {node: '>=22.0.0'}
 
   '@theholocron/http-client@0.6.0':
     resolution: {integrity: sha512-e3Y42FmikXGuP1Par2oNT1tJfiA13Qg1Ek8TK3xjWu2hReJOUr+PrNw+yDjJkJfDu0G+ihGdHuQzIydlq8ro0Q==}
@@ -4549,10 +4555,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/cli@2.0.0-alpha.36':
+  '@theholocron/cli@2.0.0-alpha.56':
     dependencies:
       '@napi-rs/keyring': 1.3.0
-      '@theholocron/http-client': 0.1.0
+      '@theholocron/github-client': 0.11.3
+      '@theholocron/http-client': 0.11.3
       tsx: 4.23.1
       yargs: 18.0.0
 
@@ -4571,16 +4578,21 @@ snapshots:
       '@vitest/eslint-plugin': 1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
 
-  '@theholocron/holocron-config@7.2.0(@theholocron/cli@2.0.0-alpha.36)':
+  '@theholocron/github-client@0.11.3':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.36
+      '@theholocron/http-client': 0.6.0
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.36(@theholocron/cli@2.0.0-alpha.36)':
+  '@theholocron/holocron-config@7.3.0(@theholocron/cli@2.0.0-alpha.56)':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.36
+      '@theholocron/cli': 2.0.0-alpha.56
+
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.56(@theholocron/cli@2.0.0-alpha.56)(@theholocron/github-client@0.11.3)':
+    dependencies:
+      '@theholocron/cli': 2.0.0-alpha.56
+      '@theholocron/github-client': 0.11.3
       libsodium-wrappers: 0.7.16
 
-  '@theholocron/http-client@0.1.0': {}
+  '@theholocron/http-client@0.11.3': {}
 
   '@theholocron/http-client@0.6.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,9 @@ packages:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.36
-    '@theholocron/holocron-config': ^7.2.0
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.36
+    '@theholocron/cli': 2.0.0-alpha.56
+    '@theholocron/holocron-config': ^7.3.0
+    '@theholocron/holocron-plugin-github': 2.0.0-alpha.56
 
 # Shared dep versions used across packages.
 catalog:


### PR DESCRIPTION
## Summary

Updates `holocron.config.ts` to use the flat `HolocronConfig` shape (removes `project` wrapper, promotes `name`, `repo`, `workflows` to root).

## Dependency

**Do not merge until theholocron/holocron#174 is merged to `alpha` and the resulting `@theholocron/cli` alpha is published.** The catalog pin in `pnpm-workspace.yaml` will then need to be bumped to the new version before this config is loadable.

Merge order:
1. Merge theholocron/holocron#174 → `alpha`
2. semantic-release publishes new `@theholocron/cli` alpha
3. Bump catalog pin in `pnpm-workspace.yaml`
4. Merge this PR

## Test plan

- [ ] `pnpm-workspace.yaml` catalog pin updated to the CLI version that includes the flat schema
- [ ] `holocron doctor` loads the config without error