### PR TITLE
chore: drop explicit name and repo.name (both derived automatically)

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -4,12 +4,10 @@ import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();
 export default defineConfig({
-	name: "clients",
 	description:
 		"API clients and shared HTTP primitives for theholocron tooling.",
 	repo: {
 		...repo,
-		name: "theholocron/clients",
 		topics: [
 			"api",
 			"api-client",


### PR DESCRIPTION
## Summary

- Removes `name` — derived from `package.json` (`@theholocron/clients` → `clients`)
- Removes `repo.name` — derived from `git remote get-url origin`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->