### PR TITLE
fix(google-client): add @types/node to devDependencies

### DIFF
--- a/packages/google-client/package.json
+++ b/packages/google-client/package.json
@@ -35,6 +35,7 @@
     "@theholocron/tsconfig": "catalog:",
     "@theholocron/tsdown-config": "catalog:",
     "@theholocron/vitest-config": "catalog:",
+    "@types/node": "^26.1.1",
     "@types/server-destroy": "^1.0.4",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/eslint-plugin": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       '@theholocron/vitest-config':
         specifier: 'catalog:'
         version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/server-destroy':
         specifier: ^1.0.4
         version: 1.0.4


### PR DESCRIPTION
## Summary

- Adds `@types/node: "^26.1.1"` to `google-client` devDependencies, matching every other package in the monorepo that imports from `node:http` / `node:url`

## Test plan

- [x] `pnpm --filter @theholocron/google-client typecheck` passes

Closes #154
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->