### PR TITLE
docs: add missing packages to root README and fix stale version strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ API clients and shared HTTP primitives used across the Galaxy.
 | [`@theholocron/doppler-client`](./packages/doppler-client)       | TypeScript client for the Doppler API                                                 |
 | [`@theholocron/github-client`](./packages/github-client)         | TypeScript client for the GitHub REST API                                             |
 | [`@theholocron/google-client`](./packages/google-client)         | TypeScript client for Google Workspace (Docs, Sheets)                                 |
+| [`@theholocron/infisical-client`](./packages/infisical-client)   | TypeScript client for the Infisical API                                               |
 | [`@theholocron/jira-client`](./packages/jira-client)             | TypeScript client for the Jira REST API                                               |
+| [`@theholocron/neon-client`](./packages/neon-client)             | TypeScript client for the Neon API                                                    |
+| [`@theholocron/postman-client`](./packages/postman-client)       | TypeScript client for the Postman API                                                 |
+| [`@theholocron/vercel-client`](./packages/vercel-client)         | TypeScript client for the Vercel API                                                  |
 | [`@theholocron/zendesk-client`](./packages/zendesk-client)       | TypeScript client for the Zendesk API                                                 |
 
 ## Development

--- a/packages/clerk-client/README.md
+++ b/packages/clerk-client/README.md
@@ -45,4 +45,4 @@ await clerk.users.unlock("user_abc123");
 
 ## Status
 
-`v0.3.2` — published on npm. APIs may shift before v1.
+`v0.11.3` — published on npm. APIs may shift before v1.

--- a/packages/doppler-client/README.md
+++ b/packages/doppler-client/README.md
@@ -42,4 +42,4 @@ await doppler.environments.create("my-project", "Staging", "stg");
 
 ## Status
 
-`v0.5.0` — published on npm. APIs may shift before v1.
+`v0.11.3` — published on npm. APIs may shift before v1.

--- a/packages/infisical-client/README.md
+++ b/packages/infisical-client/README.md
@@ -58,4 +58,4 @@ await infisical.secrets.update("DB_URL", {
 
 ## Status
 
-`v0.7.0` — published on npm. APIs may shift before v1.
+`v0.11.3` — published on npm. APIs may shift before v1.

--- a/packages/neon-client/README.md
+++ b/packages/neon-client/README.md
@@ -55,4 +55,4 @@ await neon.branches.destroy("my-project-id", branch.id);
 
 ## Status
 
-`v0.6.2` — published on npm. APIs may shift before v1.
+`v0.11.3` — published on npm. APIs may shift before v1.

--- a/packages/postman-client/README.md
+++ b/packages/postman-client/README.md
@@ -67,4 +67,4 @@ await postman.specs.updateFile(
 
 ## Status
 
-`v0.8.0` — published on npm. APIs may shift before v1.
+`v0.11.3` — published on npm. APIs may shift before v1.

--- a/packages/vercel-client/README.md
+++ b/packages/vercel-client/README.md
@@ -64,4 +64,4 @@ const status = await vercel.deployments.get(deployment.id);
 
 ## Status
 
-`v0.9.0` — published on npm. APIs may shift before v1.
+`v0.11.3` — published on npm. APIs may shift before v1.


### PR DESCRIPTION
## Summary

- Add `infisical-client`, `neon-client`, `postman-client`, `vercel-client` rows to the root `README.md` packages table — all four were added after the README was last updated (#155)
- Fix `## Status` version strings in 6 package READMEs from stale early-release values (`v0.3.2`–`v0.9.0`) to `v0.11.3` (#156)
- Note: `jira-client` has no Status section (the `v1.2.0` in the issue body referred to a Jira API version string in the code example, not the package version)

## Test plan

- [x] Documentation-only changes — no code affected

Closes #155, #156
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->