### PR TITLE
test: improve branch coverage in postman, vercel, and zendesk

### DIFF
--- a/packages/postman-client/src/__tests__/client.test.ts
+++ b/packages/postman-client/src/__tests__/client.test.ts
@@ -48,4 +48,22 @@ describe("createPostmanClient", () => {
 		expect((err as Error).name).toBe("PostmanPlanLimitError");
 		expect((err as Error).message).toBe("upgrade required");
 	});
+
+	it("re-throws ProviderApiError when error body is non-JSON", async () => {
+		const { fetch } = stubFetch([
+			{ status: 403, text: "not-json" },
+		]);
+		const client = createPostmanClient({ token: TOKEN, fetch });
+		const err = await client.specs.list("ws1").catch((e: unknown) => e);
+		expect((err as Error).name).toBe("ProviderApiError");
+	});
+
+	it("re-throws ProviderApiError when error body is valid JSON but not a plan limit", async () => {
+		const { fetch } = stubFetch([
+			{ status: 500, text: JSON.stringify({ message: "internal error" }) },
+		]);
+		const client = createPostmanClient({ token: TOKEN, fetch });
+		const err = await client.specs.list("ws1").catch((e: unknown) => e);
+		expect((err as Error).name).toBe("ProviderApiError");
+	});
 });

--- a/packages/postman-client/src/__tests__/client.test.ts
+++ b/packages/postman-client/src/__tests__/client.test.ts
@@ -50,9 +50,7 @@ describe("createPostmanClient", () => {
 	});
 
 	it("re-throws ProviderApiError when error body is non-JSON", async () => {
-		const { fetch } = stubFetch([
-			{ status: 403, text: "not-json" },
-		]);
+		const { fetch } = stubFetch([{ status: 403, text: "not-json" }]);
 		const client = createPostmanClient({ token: TOKEN, fetch });
 		const err = await client.specs.list("ws1").catch((e: unknown) => e);
 		expect((err as Error).name).toBe("ProviderApiError");
@@ -60,7 +58,10 @@ describe("createPostmanClient", () => {
 
 	it("re-throws ProviderApiError when error body is valid JSON but not a plan limit", async () => {
 		const { fetch } = stubFetch([
-			{ status: 500, text: JSON.stringify({ message: "internal error" }) },
+			{
+				status: 500,
+				text: JSON.stringify({ message: "internal error" }),
+			},
 		]);
 		const client = createPostmanClient({ token: TOKEN, fetch });
 		const err = await client.specs.list("ws1").catch((e: unknown) => e);

--- a/packages/vercel-client/src/__tests__/resources.test.ts
+++ b/packages/vercel-client/src/__tests__/resources.test.ts
@@ -94,6 +94,18 @@ describe("projects.update", () => {
 			previewDeploymentsDisabled: true,
 		});
 	});
+
+	it("includes gitProviderOptions when provided", async () => {
+		const { client, calls } = makeClient([
+			{ body: { id: "p1", name: "my-app" } },
+		]);
+		await client.projects.update("p1", {
+			gitProviderOptions: { createDeployments: true },
+		});
+		expect(calls[0]?.body).toMatchObject({
+			gitProviderOptions: { createDeployments: true },
+		});
+	});
 });
 
 describe("env.list", () => {

--- a/packages/zendesk-client/src/__tests__/client.test.ts
+++ b/packages/zendesk-client/src/__tests__/client.test.ts
@@ -193,8 +193,14 @@ describe("fields", () => {
 
 describe("error handling", () => {
 	it("throws ProviderApiError on non-2xx response", async () => {
-		const { fetch } = stubFetch([{ status: 422, body: { error: "invalid" } }]);
-		const client = createZendeskClient({ baseUrl: BASE, token: TOKEN, fetch });
+		const { fetch } = stubFetch([
+			{ status: 422, body: { error: "invalid" } },
+		]);
+		const client = createZendeskClient({
+			baseUrl: BASE,
+			token: TOKEN,
+			fetch,
+		});
 		const err = await client.tickets.get(999).catch((e: unknown) => e);
 		expect((err as Error).name).toBe("ProviderApiError");
 	});

--- a/packages/zendesk-client/src/__tests__/client.test.ts
+++ b/packages/zendesk-client/src/__tests__/client.test.ts
@@ -190,3 +190,12 @@ describe("fields", () => {
 		expect(calls[0]?.method).toBe("DELETE");
 	});
 });
+
+describe("error handling", () => {
+	it("throws ProviderApiError on non-2xx response", async () => {
+		const { fetch } = stubFetch([{ status: 422, body: { error: "invalid" } }]);
+		const client = createZendeskClient({ baseUrl: BASE, token: TOKEN, fetch });
+		const err = await client.tickets.get(999).catch((e: unknown) => e);
+		expect((err as Error).name).toBe("ProviderApiError");
+	});
+});


### PR DESCRIPTION
## Summary

Several packages had thin branch coverage in areas the issue (#161) specifically called out (error path, non-obvious branches):

- **postman-client**: add two error-path tests covering the non-JSON body path in `detectPlanLimit` (catch branch, previously uncovered) and the non-`limitReachedError` path in the request wrapper (`if (limit)` false branch)
- **vercel-client**: add test for `projects.update` with `gitProviderOptions` (branch was only exercised when the argument was absent)
- **zendesk-client**: add `ProviderApiError` error-path test (API returns non-2xx)

Note: `jira-client` and `confluence-client` already had their coverage addressed — jira by PR #179 and confluence had 100% coverage already.

## Test plan

- [x] `pnpm test` — all 12 packages pass

Closes #161
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->