### PR TITLE
chore: sync description and keywords from holocron.config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,20 @@
   "name": "@theholocron/clients",
   "version": "0.0.0",
   "private": true,
-  "description": "API Clients used within the Galaxy.",
+  "description": "API clients and shared HTTP primitives for theholocron tooling.",
+  "keywords": [
+    "api",
+    "api-client",
+    "client",
+    "confluence",
+    "google",
+    "http-client",
+    "jira",
+    "nodejs",
+    "rest",
+    "typescript",
+    "zendesk"
+  ],
   "homepage": "https://github.com/theholocron/clients#readme",
   "bugs": "https://github.com/theholocron/clients/issues",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@theholocron/clients",
   "version": "0.0.0",
   "private": true,
-  "description": "API clients and shared HTTP primitives for theholocron tooling.",
+  "description": "API clients and shared HTTP primitives.",
   "keywords": [
     "api",
     "api-client",


### PR DESCRIPTION
## Summary

- Updates root `package.json` `description` to match `holocron.config.ts`
- Adds `keywords` mirroring `repo.topics` from `holocron.config.ts`

Both were drifting — `package.json` had stale copy; the config file is the source of truth.

> **Note:** `holocron sync keywords description` handles this going forward — no manual PR needed next time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->