### PR TITLE
chore: use semver range for holocron catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,13 +62,13 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.56
+      specifier: '>=2.0.0-alpha.0 <2.0.0'
       version: 2.0.0-alpha.56
     '@theholocron/holocron-config':
       specifier: ^7.3.0
       version: 7.3.0
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.56
+      specifier: '>=2.0.0-alpha.0 <2.0.0'
       version: 2.0.0-alpha.56
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,12 @@
 packages:
   - 'packages/*'
 
-# Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
+# Holocron CLI and plugins — range covers all alpha releases; switch to ^2.0.0 on stable.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.56
+    '@theholocron/cli': '>=2.0.0-alpha.0 <2.0.0'
     '@theholocron/holocron-config': ^7.3.0
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.56
+    '@theholocron/holocron-plugin-github': '>=2.0.0-alpha.0 <2.0.0'
 
 # Shared dep versions used across packages.
 catalog:


### PR DESCRIPTION
Switch the holocron catalog pins from hardcoded alpha versions to `>=2.0.0-alpha.0 <2.0.0` so new alpha releases are picked up automatically on `pnpm install`. Update to `^2.0.0` when stable ships.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->