### PR TITLE
feat(github-client): add teams module for org team-repo access

### DIFF
--- a/packages/github-client/src/__tests__/teams.test.ts
+++ b/packages/github-client/src/__tests__/teams.test.ts
@@ -10,7 +10,9 @@ describe("teams", () => {
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.teams.addRepo(ORG, "gatekeepers", ORG, REPO_NAME, "push");
 		expect(calls[0]?.method).toBe("PUT");
-		expect(calls[0]?.url).toContain(`/orgs/${ORG}/teams/gatekeepers/repos/${ORG}/${REPO_NAME}`);
+		expect(calls[0]?.url).toContain(
+			`/orgs/${ORG}/teams/gatekeepers/repos/${ORG}/${REPO_NAME}`,
+		);
 		expect(calls[0]?.body).toEqual({ permission: "push" });
 	});
 

--- a/packages/github-client/src/__tests__/teams.test.ts
+++ b/packages/github-client/src/__tests__/teams.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../index.js";
+import { stubFetch, TOKEN, REPO } from "./helpers.js";
+
+const [ORG, REPO_NAME] = REPO.split("/") as [string, string];
+
+describe("teams", () => {
+	it("PUT /orgs/{org}/teams/{slug}/repos/{owner}/{repo} with permission", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.teams.addRepo(ORG, "gatekeepers", ORG, REPO_NAME, "push");
+		expect(calls[0]?.method).toBe("PUT");
+		expect(calls[0]?.url).toContain(`/orgs/${ORG}/teams/gatekeepers/repos/${ORG}/${REPO_NAME}`);
+		expect(calls[0]?.body).toEqual({ permission: "push" });
+	});
+
+	it("passes the specified permission verbatim", async () => {
+		const { fetch, calls } = stubFetch([{ status: 204 }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.teams.addRepo(ORG, "admins", ORG, REPO_NAME, "maintain");
+		expect(calls[0]?.body).toEqual({ permission: "maintain" });
+	});
+});

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -9,6 +9,7 @@ import { repos } from "./repos/repos.js";
 import { rulesets } from "./rulesets/rulesets.js";
 import { secrets } from "./secrets/secrets.js";
 import { security } from "./security/security.js";
+import { teams } from "./teams/teams.js";
 import { topics } from "./topics/topics.js";
 import { user } from "./user/user.js";
 import { workflows } from "./workflows/workflows.js";
@@ -41,6 +42,7 @@ export type {
 	GitTreeItem,
 } from "./git/git.js";
 export type { GitHubUser } from "./user/user.js";
+export type { TeamPermission } from "./teams/teams.js";
 
 export function createGitHubClient(opts: GitHubClientOptions) {
 	const rest = createGitHubRestClient(opts);
@@ -55,6 +57,7 @@ export function createGitHubClient(opts: GitHubClientOptions) {
 		rulesets: rulesets(rest),
 		secrets: secrets(rest),
 		security: security(rest),
+		teams: teams(rest),
 		topics: topics(rest),
 		user: user(rest),
 		workflows: workflows(rest),

--- a/packages/github-client/src/teams/teams.ts
+++ b/packages/github-client/src/teams/teams.ts
@@ -4,10 +4,19 @@ export type TeamPermission = "pull" | "triage" | "push" | "maintain" | "admin";
 
 export function teams(rest: RestClient) {
 	return {
-		addRepo: (org: string, teamSlug: string, owner: string, repo: string, permission: TeamPermission): Promise<void> =>
-			rest.request<void>(`/orgs/${org}/teams/${teamSlug}/repos/${owner}/${repo}`, {
-				method: "PUT",
-				body: { permission },
-			}),
+		addRepo: (
+			org: string,
+			teamSlug: string,
+			owner: string,
+			repo: string,
+			permission: TeamPermission,
+		): Promise<void> =>
+			rest.request<void>(
+				`/orgs/${org}/teams/${teamSlug}/repos/${owner}/${repo}`,
+				{
+					method: "PUT",
+					body: { permission },
+				},
+			),
 	};
 }

--- a/packages/github-client/src/teams/teams.ts
+++ b/packages/github-client/src/teams/teams.ts
@@ -1,0 +1,13 @@
+import type { RestClient } from "../utils.js";
+
+export type TeamPermission = "pull" | "triage" | "push" | "maintain" | "admin";
+
+export function teams(rest: RestClient) {
+	return {
+		addRepo: (org: string, teamSlug: string, owner: string, repo: string, permission: TeamPermission): Promise<void> =>
+			rest.request<void>(`/orgs/${org}/teams/${teamSlug}/repos/${owner}/${repo}`, {
+				method: "PUT",
+				body: { permission },
+			}),
+	};
+}


### PR DESCRIPTION
## Summary

- Adds `teams(rest)` factory to `github-client` with an `addRepo(org, slug, owner, repo, permission)` method mapping to `PUT /orgs/{org}/teams/{slug}/repos/{owner}/{repo}`
- Exports `TeamPermission` type (`"pull" | "triage" | "push" | "maintain" | "admin"`)
- Registers `teams` in the client returned by `createGitHubClient`

## Test plan

- [ ] `pnpm --filter @theholocron/github-client test` — 2 new tests covering PUT request shape and permission passthrough
- [ ] `pnpm --filter @theholocron/github-client typecheck` — clean

**Ship order:** This PR must merge and publish before the companion `holocron` PR (`feat/setup-teams-codeowners`) can remove its `TeamCapableClient` type bridge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/clients/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->