### PR TITLE
chore: add Knip for unused file, export, and dependency detection

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -1,0 +1,36 @@
+name: Knip
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main, alpha]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  knip:
+    name: Knip
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v6.0.9
+        name: Setup pnpm
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        name: Setup Node
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        name: Install dependencies
+
+      - run: pnpm audit
+        name: Run Knip

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -32,5 +32,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
         name: Install dependencies
 
-      - run: pnpm audit
+      - run: pnpm run audit
         name: Run Knip

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,50 @@
+import type { KnipConfig } from "knip";
+
+const config: KnipConfig = {
+	workspaces: {
+		".": {
+			// prettier.config.ts, eslint.config.ts, release.config.ts auto-detected by Knip plugins
+			entry: ["commitlint.config.ts", "holocron.config.ts"],
+			project: ["*.ts"],
+		},
+		"packages/*": {
+			// entry points auto-detected from package.json exports
+			// vitest.config.ts re-exports a shared bundle so Knip can't trace
+			// the include patterns — declare test entry points explicitly
+			entry: ["src/__tests__/**/*.test.ts", "examples.ts"],
+			project: ["src/**/*.ts"],
+		},
+	},
+	ignoreDependencies: [
+		// Loaded at runtime by the holocron plugin system — not a static import
+		"@theholocron/holocron-plugin-github",
+		// Used by the skills runtime, not a module import
+		"@theholocron/skills",
+		// ESLint toolchain: root eslint.config.ts imports the bundle; per-package
+		// eslint.config.ts files aren't traced by Knip's ESLint plugin
+		"@theholocron/eslint-config",
+		"eslint-plugin-n",
+		"globals",
+		// tsconfig.json "extends" — not a module import
+		"@theholocron/tsconfig",
+		// commitlint "extends" uses string shorthand — Knip sees the bare scoped
+		// org "@theholocron" rather than "@theholocron/commitlint-config"
+		"@theholocron/commitlint-config",
+		"@theholocron",
+		// pinned as a pnpm override; not directly imported by root code
+		"@commitlint/config-conventional",
+		// passed as --config arg to lint-staged binary in .husky/pre-commit
+		"@theholocron/lint-staged-config",
+		// prettier config package — no .prettierrc or prettier.config.ts at root
+		"@theholocron/prettier-config",
+		// binary tools — invoked via CLI or hooks, not module imports
+		"alexjs",
+		"husky",
+		"turbo",
+	],
+	// commitlint binary comes from @commitlint/cli, not a direct bin reference
+	ignoreBinaries: ["commitlint"],
+	ignoreExportsUsedInFile: true,
+};
+
+export default config;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,6 @@ catalog:
   eslint-plugin-n: ^18.2.2
   globals: ^17.7.0
   tsdown: ^0.22.8
-  tsx: ^4.23.0
   typescript: ^5.9.3
   vitest: ^4.1.10
 


### PR DESCRIPTION
Closes #198

## Summary

- Adds `knip@^6.27.0` as a root devDependency and a `pnpm audit` script that runs it
- Adds `knip.config.ts` with workspace definitions for the root and all `packages/*`, explicit test entry points, and `ignoreDependencies` for deps that can't be traced statically (runtime plugin loads, CLI `--config` args, string-based commitlint `extends`, tsconfig `"extends"` references)
- Declares `src/__tests__/**/*.test.ts` as explicit per-package entry points because each package's `vitest.config.ts` re-exports a shared bundle that Knip cannot trace through
- Adds `.github/workflows/knip.yml` running Knip on every push/PR as a non-blocking check (`continue-on-error: true`) until the baseline is established
- Removes the stale `tsx` catalog entry from `pnpm-workspace.yaml` — the first real finding Knip surfaced (no package referenced it)

## Test plan

- [ ] `pnpm audit` exits 0 with no output (zero findings after config tuning)
- [ ] `pnpm install --frozen-lockfile` passes
- [ ] CI Knip workflow runs and passes on this PR