### PR TITLE
chore: bump holocron cli to 2.1.1, add turborepo skill, run setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-21T21:49:28.687Z
+# Synced:  2026-07-22T15:51:38.862Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-21T18:24:52.699Z
+# Synced:  2026-07-22T15:51:38.862Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,8 +1,8 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-22T06:20:18.863Z
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Synced:  2026-07-22T15:51:38.861Z
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Audit
 
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -3,28 +3,19 @@
 # Synced:  2026-07-22T15:51:38.861Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
-name: Release
+name: Bookkeeping
 
 on: # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - main
-      - alpha
-  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
 
 permissions:
-  contents: write
-  id-token: write
-  issues: write
+  contents: read
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  release:
-    uses: theholocron/.github/.github/workflows/release.yml@main
-    with:
-      run-build: true
+  bookkeeping:
+    uses: theholocron/.github/.github/workflows/bookkeeping.yml@main
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.757Z
+# Synced:  2026-07-22T15:51:38.859Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.758Z
+# Synced:  2026-07-22T15:51:38.860Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.758Z
+# Synced:  2026-07-22T15:51:38.860Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.753Z
+# Synced:  2026-07-22T15:51:38.856Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.757Z
+# Synced:  2026-07-22T15:51:38.859Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.757Z
+# Synced:  2026-07-22T15:51:38.859Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Stale

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.756Z
+# Synced:  2026-07-22T15:51:38.858Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:13:21.756Z
+# Synced:  2026-07-22T15:51:38.859Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,5 @@ service-account*.json
 /.claude/skills/commit-standards
 /.claude/skills/security-review
 /.claude/skills/holocron-skill-client
+/.claude/skills/turborepo
 # end managed by holocron setup — skills

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -38,5 +38,6 @@ export default defineConfig({
 		"commit-standards",
 		"security-review",
 		"holocron-skill-client",
+		"turborepo",
 	],
 } satisfies HolocronConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,14 +62,14 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: ^2.0.0
-      version: 2.0.1
+      specifier: ^2.1.1
+      version: 2.1.1
     '@theholocron/holocron-config':
       specifier: ^7.4.1
       version: 7.4.1
     '@theholocron/holocron-plugin-github':
-      specifier: '>=2.0.0-alpha.0 <2.0.0'
-      version: 2.0.0-alpha.71
+      specifier: ^2.1.1
+      version: 2.1.1
 
 overrides:
   '@commitlint/config-conventional': ^21.2.0
@@ -101,7 +101,7 @@ importers:
         version: 10.0.1(semantic-release@25.0.8(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.1(vitest@4.1.10)
+        version: 2.1.1(vitest@4.1.10)
       '@theholocron/commitlint-config':
         specifier: 'catalog:'
         version: 7.4.1(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)
@@ -110,10 +110,10 @@ importers:
         version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:holocron
-        version: 7.4.1(@theholocron/cli@2.0.1(vitest@4.1.10))
+        version: 7.4.1(@theholocron/cli@2.1.1(vitest@4.1.10))
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.71(@theholocron/cli@2.0.1(vitest@4.1.10))(@theholocron/github-client@1.3.1(vitest@4.1.10))
+        version: 2.1.1(@theholocron/cli@2.1.1(vitest@4.1.10))(@theholocron/github-client@1.3.1(vitest@4.1.10))
       '@theholocron/lint-staged-config':
         specifier: 'catalog:'
         version: 7.4.1(husky@9.1.7)(lint-staged@16.4.0)
@@ -1754,8 +1754,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/cli@2.0.1':
-    resolution: {integrity: sha512-yhFy0+HIVwphSDDbFDtMmz+EStCbTl5wQ2d5CaysCt+4tbZ/CeGOSnuYJVnOTrrQOof66vGWPYTQWydrYTkscA==}
+  '@theholocron/cli@2.1.1':
+    resolution: {integrity: sha512-rjIiTf78Z1m39IW6P6Fq1r7CYDRJ+era+XBjg9aEm9K1BhAHXOy9zODekHPkVO74sRtRoR4qUw38muszeBnvHw==}
     hasBin: true
 
   '@theholocron/commitlint-config@7.4.1':
@@ -1803,11 +1803,11 @@ packages:
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.71':
-    resolution: {integrity: sha512-kDxy1QpfB786C8eKkjpJceSxJ2Ym0aK9b7gxSGpvH8X4mQ6FLvncpROJoHkHDdbK8Ql2jpWpQWI+OTkxUKh0IA==}
+  '@theholocron/holocron-plugin-github@2.1.1':
+    resolution: {integrity: sha512-yND4TdjgUuMGhhy1GLGWosaIdzJzxJFVtccOULbK7NN1ZmNRcMoLhH63GLxt8wWYFsUKs1cRlUg4niJdI2vKiA==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.71
-      '@theholocron/github-client': ^1.1.0
+      '@theholocron/cli': 2.1.1
+      '@theholocron/github-client': ^1.3.0
 
   '@theholocron/http-client@0.11.5':
     resolution: {integrity: sha512-FLQS8pW8QIYjY18paJF+evjNn7FApXJ+Z+PWmgFD1gKea+jXkVv8S8ihvSvES8kLmqKtDoUKK17yYgdeg8VHsg==}
@@ -3205,11 +3205,11 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsodium-wrappers@0.7.16:
-    resolution: {integrity: sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==}
+  libsodium-wrappers@0.8.4:
+    resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
 
-  libsodium@0.7.16:
-    resolution: {integrity: sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==}
+  libsodium@0.8.4:
+    resolution: {integrity: sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -5266,7 +5266,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/cli@2.0.1(vitest@4.1.10)':
+  '@theholocron/cli@2.1.1(vitest@4.1.10)':
     dependencies:
       '@napi-rs/keyring': 1.3.0
       '@theholocron/github-client': 1.3.1(vitest@4.1.10)
@@ -5299,15 +5299,15 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-config@7.4.1(@theholocron/cli@2.0.1(vitest@4.1.10))':
+  '@theholocron/holocron-config@7.4.1(@theholocron/cli@2.1.1(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 2.0.1(vitest@4.1.10)
+      '@theholocron/cli': 2.1.1(vitest@4.1.10)
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.71(@theholocron/cli@2.0.1(vitest@4.1.10))(@theholocron/github-client@1.3.1(vitest@4.1.10))':
+  '@theholocron/holocron-plugin-github@2.1.1(@theholocron/cli@2.1.1(vitest@4.1.10))(@theholocron/github-client@1.3.1(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 2.0.1(vitest@4.1.10)
+      '@theholocron/cli': 2.1.1(vitest@4.1.10)
       '@theholocron/github-client': 1.3.1(vitest@4.1.10)
-      libsodium-wrappers: 0.7.16
+      libsodium-wrappers: 0.8.4
 
   '@theholocron/http-client@0.11.5': {}
 
@@ -6638,11 +6638,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsodium-wrappers@0.7.16:
+  libsodium-wrappers@0.8.4:
     dependencies:
-      libsodium: 0.7.16
+      libsodium: 0.8.4
 
-  libsodium@0.7.16: {}
+  libsodium@0.8.4: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,6 @@ catalog:
 # Holocron CLI and plugins — range covers all alpha releases; switch to ^2.0.0 on stable.
 catalogs:
   holocron:
-    '@theholocron/cli': ^2.0.0
+    '@theholocron/cli': ^2.1.1
     '@theholocron/holocron-config': ^7.4.1
-    '@theholocron/holocron-plugin-github': '>=2.0.0-alpha.0 <2.0.0'
+    '@theholocron/holocron-plugin-github': ^2.1.1


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/cli` and `@theholocron/holocron-plugin-github` to `^2.1.1` in `pnpm-workspace.yaml` (was `^2.0.0`/`>=2.0.0-alpha.0 <2.0.0` — the old alpha range didn't match any stable release)
- Adds `"turborepo"` to `skills` in `holocron.config.ts` — fetched from `vercel/turbo` via `skills-lock.json` during setup
- Runs `holocron setup` — picks up workflow and config drift, installs all 6 skills including the external turborepo skill (noted as stale; run `holocron skills update` to refresh the lock hash)

## Test plan

- [ ] CI green
- [ ] `holocron setup` output files (workflows, .editorconfig, .gitignore) match what CI expects