### PR TITLE
chore(deps): bump @theholocron/eslint-config to 7.6.0, sort imports

### DIFF
--- a/packages/clerk-client/eslint.config.ts
+++ b/packages/clerk-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/clerk-client/package.json
+++ b/packages/clerk-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/clerk-client/src/__tests__/client.test.ts
+++ b/packages/clerk-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createClerkClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/clerk-client/src/__tests__/instance.test.ts
+++ b/packages/clerk-client/src/__tests__/instance.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createClerkClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/clerk-client/src/__tests__/users.test.ts
+++ b/packages/clerk-client/src/__tests__/users.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createClerkClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/clerk-client/src/__tests__/webhooks.test.ts
+++ b/packages/clerk-client/src/__tests__/webhooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createClerkClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/clerk-client/src/index.ts
+++ b/packages/clerk-client/src/index.ts
@@ -1,12 +1,9 @@
-import { createClerkRestClient, type ClerkClientOptions } from "./utils.js";
 import { instance } from "./instance/instance.js";
 import { users } from "./users/users.js";
+import { type ClerkClientOptions,createClerkRestClient } from "./utils.js";
 import { webhooks } from "./webhooks/webhooks.js";
 
-export type { ClerkClientOptions } from "./utils.js";
-
 export type { ClerkInstance } from "./instance/instance.js";
-
 export type {
 	ClerkDeletedObject,
 	ClerkEmailAddress,
@@ -17,7 +14,7 @@ export type {
 	CreateClerkUserInput,
 	UpdateClerkUserInput,
 } from "./users/users.js";
-
+export type { ClerkClientOptions } from "./utils.js";
 export type { ClerkSvixApp, ClerkSvixUrl } from "./webhooks/webhooks.js";
 
 export function createClerkClient(opts: ClerkClientOptions) {

--- a/packages/clerk-client/src/index.ts
+++ b/packages/clerk-client/src/index.ts
@@ -1,6 +1,6 @@
 import { instance } from "./instance/instance.js";
 import { users } from "./users/users.js";
-import { type ClerkClientOptions,createClerkRestClient } from "./utils.js";
+import { type ClerkClientOptions, createClerkRestClient } from "./utils.js";
 import { webhooks } from "./webhooks/webhooks.js";
 
 export type { ClerkInstance } from "./instance/instance.js";

--- a/packages/confluence-client/eslint.config.ts
+++ b/packages/confluence-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/confluence-client/package.json
+++ b/packages/confluence-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/doppler-client/eslint.config.ts
+++ b/packages/doppler-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/doppler-client/package.json
+++ b/packages/doppler-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/doppler-client/src/__tests__/client.test.ts
+++ b/packages/doppler-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createDopplerClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/doppler-client/src/__tests__/environments.test.ts
+++ b/packages/doppler-client/src/__tests__/environments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createDopplerClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/doppler-client/src/__tests__/me.test.ts
+++ b/packages/doppler-client/src/__tests__/me.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createDopplerClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/doppler-client/src/__tests__/projects.test.ts
+++ b/packages/doppler-client/src/__tests__/projects.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createDopplerClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/doppler-client/src/__tests__/secrets.test.ts
+++ b/packages/doppler-client/src/__tests__/secrets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createDopplerClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/doppler-client/src/index.ts
+++ b/packages/doppler-client/src/index.ts
@@ -1,10 +1,8 @@
-import { createDopplerRestClient, type DopplerClientOptions } from "./utils.js";
 import { environments } from "./environments/environments.js";
 import { me } from "./me/me.js";
 import { projects } from "./projects/projects.js";
 import { secrets } from "./secrets/secrets.js";
-
-export type { DopplerClientOptions } from "./utils.js";
+import { createDopplerRestClient, type DopplerClientOptions } from "./utils.js";
 
 export type {
 	DopplerEnvironment,
@@ -17,9 +15,10 @@ export type {
 } from "./projects/projects.js";
 export type {
 	DopplerSecret,
-	DopplerSecretValue,
 	DopplerSecretsMap,
+	DopplerSecretValue,
 } from "./secrets/secrets.js";
+export type { DopplerClientOptions } from "./utils.js";
 
 export function createDopplerClient(opts: DopplerClientOptions) {
 	const rest = createDopplerRestClient(opts);

--- a/packages/github-client/eslint.config.ts
+++ b/packages/github-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/github-client/src/__tests__/branches.test.ts
+++ b/packages/github-client/src/__tests__/branches.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("branches", () => {
 	it("PUT /repos/{owner}/{name}/branches/{branch}/protection", async () => {

--- a/packages/github-client/src/__tests__/branches.test.ts
+++ b/packages/github-client/src/__tests__/branches.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("branches", () => {
 	it("PUT /repos/{owner}/{name}/branches/{branch}/protection", async () => {

--- a/packages/github-client/src/__tests__/client.test.ts
+++ b/packages/github-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
 import { stubFetch, TOKEN } from "./helpers.js";
 

--- a/packages/github-client/src/__tests__/environments.test.ts
+++ b/packages/github-client/src/__tests__/environments.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("environments", () => {
 	it("GET /repos/{owner}/{name}/environments", async () => {

--- a/packages/github-client/src/__tests__/environments.test.ts
+++ b/packages/github-client/src/__tests__/environments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("environments", () => {
 	it("GET /repos/{owner}/{name}/environments", async () => {

--- a/packages/github-client/src/__tests__/git.test.ts
+++ b/packages/github-client/src/__tests__/git.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("git", () => {
 	it("GET /repos/{owner}/{name}/git/ref/heads/{branch}", async () => {

--- a/packages/github-client/src/__tests__/git.test.ts
+++ b/packages/github-client/src/__tests__/git.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("git", () => {
 	it("GET /repos/{owner}/{name}/git/ref/heads/{branch}", async () => {

--- a/packages/github-client/src/__tests__/issues.test.ts
+++ b/packages/github-client/src/__tests__/issues.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 const RAW_ISSUE = {
 	id: 1,

--- a/packages/github-client/src/__tests__/issues.test.ts
+++ b/packages/github-client/src/__tests__/issues.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 const RAW_ISSUE = {
 	id: 1,

--- a/packages/github-client/src/__tests__/labels.test.ts
+++ b/packages/github-client/src/__tests__/labels.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 const RAW_LABELS = [
 	{ name: "bug", color: "d73a4a", description: "Something isn't working" },

--- a/packages/github-client/src/__tests__/labels.test.ts
+++ b/packages/github-client/src/__tests__/labels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 const RAW_LABELS = [
 	{ name: "bug", color: "d73a4a", description: "Something isn't working" },

--- a/packages/github-client/src/__tests__/properties.test.ts
+++ b/packages/github-client/src/__tests__/properties.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("properties", () => {
 	it("PATCH /repos/{owner}/{name}/properties/values", async () => {

--- a/packages/github-client/src/__tests__/properties.test.ts
+++ b/packages/github-client/src/__tests__/properties.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("properties", () => {
 	it("PATCH /repos/{owner}/{name}/properties/values", async () => {

--- a/packages/github-client/src/__tests__/repos.test.ts
+++ b/packages/github-client/src/__tests__/repos.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("repos", () => {
 	it("GET /repos/{owner}/{name}", async () => {

--- a/packages/github-client/src/__tests__/repos.test.ts
+++ b/packages/github-client/src/__tests__/repos.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("repos", () => {
 	it("GET /repos/{owner}/{name}", async () => {

--- a/packages/github-client/src/__tests__/rulesets.test.ts
+++ b/packages/github-client/src/__tests__/rulesets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 const RULESET = {
 	id: 1,

--- a/packages/github-client/src/__tests__/rulesets.test.ts
+++ b/packages/github-client/src/__tests__/rulesets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 const RULESET = {
 	id: 1,

--- a/packages/github-client/src/__tests__/secrets.test.ts
+++ b/packages/github-client/src/__tests__/secrets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("secrets", () => {
 	it("lists repo secrets", async () => {

--- a/packages/github-client/src/__tests__/secrets.test.ts
+++ b/packages/github-client/src/__tests__/secrets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("secrets", () => {
 	it("lists repo secrets", async () => {

--- a/packages/github-client/src/__tests__/security.test.ts
+++ b/packages/github-client/src/__tests__/security.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("security", () => {
 	it("PUT vulnerability-alerts", async () => {

--- a/packages/github-client/src/__tests__/security.test.ts
+++ b/packages/github-client/src/__tests__/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("security", () => {
 	it("PUT vulnerability-alerts", async () => {

--- a/packages/github-client/src/__tests__/teams.test.ts
+++ b/packages/github-client/src/__tests__/teams.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 const [ORG, REPO_NAME] = REPO.split("/") as [string, string];
 

--- a/packages/github-client/src/__tests__/teams.test.ts
+++ b/packages/github-client/src/__tests__/teams.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 const [ORG, REPO_NAME] = REPO.split("/") as [string, string];
 

--- a/packages/github-client/src/__tests__/topics.test.ts
+++ b/packages/github-client/src/__tests__/topics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 describe("topics", () => {
 	it("PUT /repos/{owner}/{name}/topics", async () => {

--- a/packages/github-client/src/__tests__/topics.test.ts
+++ b/packages/github-client/src/__tests__/topics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 describe("topics", () => {
 	it("PUT /repos/{owner}/{name}/topics", async () => {

--- a/packages/github-client/src/__tests__/user.test.ts
+++ b/packages/github-client/src/__tests__/user.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
 import { stubFetch, TOKEN } from "./helpers.js";
 

--- a/packages/github-client/src/__tests__/workflows.test.ts
+++ b/packages/github-client/src/__tests__/workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createGitHubClient } from "../index.js";
-import { REPO,stubFetch, TOKEN } from "./helpers.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
 
 const RAW_RUN = {
 	id: 1,

--- a/packages/github-client/src/__tests__/workflows.test.ts
+++ b/packages/github-client/src/__tests__/workflows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+
 import { createGitHubClient } from "../index.js";
-import { stubFetch, TOKEN, REPO } from "./helpers.js";
+import { REPO,stubFetch, TOKEN } from "./helpers.js";
 
 const RAW_RUN = {
 	id: 1,

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -1,4 +1,3 @@
-import { createGitHubRestClient, type GitHubClientOptions } from "./utils.js";
 import { branches } from "./branches/branches.js";
 import { environments } from "./environments/environments.js";
 import { git } from "./git/git.js";
@@ -12,25 +11,10 @@ import { security } from "./security/security.js";
 import { teams } from "./teams/teams.js";
 import { topics } from "./topics/topics.js";
 import { user } from "./user/user.js";
+import { createGitHubRestClient, type GitHubClientOptions } from "./utils.js";
 import { workflows } from "./workflows/workflows.js";
 
-export type { GitHubClientOptions } from "./utils.js";
-
-export type { GitHubContents, GitHubRepo } from "./repos/repos.js";
-export type { CodeScanningSetupResult } from "./security/security.js";
-export type { GitHubRuleset } from "./rulesets/rulesets.js";
-export type {
-	GitHubWorkflowRun,
-	WorkflowRunFilter,
-} from "./workflows/workflows.js";
-export type { GitHubPublicKey, SecretScope } from "./secrets/secrets.js";
 export type { GitHubEnvironment } from "./environments/environments.js";
-export type {
-	GitHubIssue,
-	GitHubMilestone,
-	IssueSearchParams,
-} from "./issues/issues.js";
-export type { GitHubLabel } from "./labels/labels.js";
 export type {
 	CreatePullInput,
 	GitBlob,
@@ -41,8 +25,23 @@ export type {
 	GitTree,
 	GitTreeItem,
 } from "./git/git.js";
-export type { GitHubUser } from "./user/user.js";
+export type {
+	GitHubIssue,
+	GitHubMilestone,
+	IssueSearchParams,
+} from "./issues/issues.js";
+export type { GitHubLabel } from "./labels/labels.js";
+export type { GitHubContents, GitHubRepo } from "./repos/repos.js";
+export type { GitHubRuleset } from "./rulesets/rulesets.js";
+export type { GitHubPublicKey, SecretScope } from "./secrets/secrets.js";
+export type { CodeScanningSetupResult } from "./security/security.js";
 export type { TeamPermission } from "./teams/teams.js";
+export type { GitHubUser } from "./user/user.js";
+export type { GitHubClientOptions } from "./utils.js";
+export type {
+	GitHubWorkflowRun,
+	WorkflowRunFilter,
+} from "./workflows/workflows.js";
 
 export function createGitHubClient(opts: GitHubClientOptions) {
 	const rest = createGitHubRestClient(opts);

--- a/packages/google-client/eslint.config.ts
+++ b/packages/google-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/google-client/package.json
+++ b/packages/google-client/package.json
@@ -50,6 +50,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/google-client/src/authentication.ts
+++ b/packages/google-client/src/authentication.ts
@@ -1,9 +1,11 @@
 import http from "node:http";
 import url from "node:url";
+
 import type { JWT, OAuth2Client } from "google-auth-library";
 import { google } from "googleapis";
 import open from "open";
 import destroyer from "server-destroy";
+
 import { loadServiceAccountKey } from "./key.js";
 
 function buildOAuth2Client(): OAuth2Client {

--- a/packages/google-client/src/documents.ts
+++ b/packages/google-client/src/documents.ts
@@ -1,4 +1,4 @@
-import { type docs_v1,google } from "googleapis";
+import { type docs_v1, google } from "googleapis";
 
 import { googleAuth } from "./authentication.js";
 import type { Return } from "./types.js";

--- a/packages/google-client/src/documents.ts
+++ b/packages/google-client/src/documents.ts
@@ -1,4 +1,5 @@
-import { google, type docs_v1 } from "googleapis";
+import { type docs_v1,google } from "googleapis";
+
 import { googleAuth } from "./authentication.js";
 import type { Return } from "./types.js";
 

--- a/packages/google-client/src/index.ts
+++ b/packages/google-client/src/index.ts
@@ -1,7 +1,7 @@
 import { documents } from "./documents.js";
 import { spreadsheets } from "./spreadsheets.js";
 
-export { oauth, googleAuth } from "./authentication.js";
+export { googleAuth,oauth } from "./authentication.js";
 export type { Return } from "./types.js";
 
 export const google = {

--- a/packages/google-client/src/index.ts
+++ b/packages/google-client/src/index.ts
@@ -1,7 +1,7 @@
 import { documents } from "./documents.js";
 import { spreadsheets } from "./spreadsheets.js";
 
-export { googleAuth,oauth } from "./authentication.js";
+export { googleAuth, oauth } from "./authentication.js";
 export type { Return } from "./types.js";
 
 export const google = {

--- a/packages/google-client/src/spreadsheets.ts
+++ b/packages/google-client/src/spreadsheets.ts
@@ -1,4 +1,5 @@
 import { google, type sheets_v4 } from "googleapis";
+
 import { googleAuth } from "./authentication.js";
 import type { Return } from "./types.js";
 

--- a/packages/http-client/eslint.config.ts
+++ b/packages/http-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -51,6 +51,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/http-client/src/__tests__/rest-client.test.ts
+++ b/packages/http-client/src/__tests__/rest-client.test.ts
@@ -229,7 +229,7 @@ describe("createRestClient — empty body response", () => {
 describe("createRestClient — non-Error thrown by fetch", () => {
 	it("wraps a string thrown by fetch as ProviderApiError", async () => {
 		const fetch = vi.fn(async () => {
-			// eslint-disable-next-line @typescript-eslint/only-throw-error
+			 
 			throw "network gone";
 		}) as unknown as typeof globalThis.fetch;
 		const err = await createRestClient({

--- a/packages/http-client/src/__tests__/rest-client.test.ts
+++ b/packages/http-client/src/__tests__/rest-client.test.ts
@@ -229,7 +229,6 @@ describe("createRestClient — empty body response", () => {
 describe("createRestClient — non-Error thrown by fetch", () => {
 	it("wraps a string thrown by fetch as ProviderApiError", async () => {
 		const fetch = vi.fn(async () => {
-			 
 			throw "network gone";
 		}) as unknown as typeof globalThis.fetch;
 		const err = await createRestClient({

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -1,13 +1,13 @@
-export { ProviderApiError } from "./errors.js";
-export {
-	createRestClient,
-	type RestClient,
-	type RequestOptions,
-	type RestClientConfig,
-} from "./rest-client.js";
 export {
 	AuthError,
 	createResolveToken,
-	type ResolveTokenInput,
 	type ResolveTokenConfig,
+	type ResolveTokenInput,
 } from "./auth-resolver.js";
+export { ProviderApiError } from "./errors.js";
+export {
+	createRestClient,
+	type RequestOptions,
+	type RestClient,
+	type RestClientConfig,
+} from "./rest-client.js";

--- a/packages/infisical-client/eslint.config.ts
+++ b/packages/infisical-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/infisical-client/package.json
+++ b/packages/infisical-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/infisical-client/src/__tests__/client.test.ts
+++ b/packages/infisical-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createInfisicalClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/infisical-client/src/__tests__/secrets.test.ts
+++ b/packages/infisical-client/src/__tests__/secrets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createInfisicalClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/infisical-client/src/__tests__/workspaces.test.ts
+++ b/packages/infisical-client/src/__tests__/workspaces.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createInfisicalClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/infisical-client/src/index.ts
+++ b/packages/infisical-client/src/index.ts
@@ -1,26 +1,25 @@
+import { secrets } from "./secrets/secrets.js";
 import {
 	createInfisicalRestClient,
 	type InfisicalClientOptions,
 } from "./utils.js";
-import { secrets } from "./secrets/secrets.js";
 import { workspaces } from "./workspaces/workspaces.js";
 
-export type { InfisicalClientOptions } from "./utils.js";
-
 export type {
+	InfisicalCreateSecretInput,
 	InfisicalSecret,
-	InfisicalSecretsListResponse,
 	InfisicalSecretResponse,
 	InfisicalSecretScope,
-	InfisicalCreateSecretInput,
+	InfisicalSecretsListResponse,
 	InfisicalUpdateSecretInput,
 } from "./secrets/secrets.js";
+export type { InfisicalClientOptions } from "./utils.js";
 export type {
 	InfisicalWorkspace,
-	InfisicalWorkspaceEnvironment,
 	InfisicalWorkspaceDetails,
-	InfisicalWorkspaceListResponse,
 	InfisicalWorkspaceDetailsResponse,
+	InfisicalWorkspaceEnvironment,
+	InfisicalWorkspaceListResponse,
 } from "./workspaces/workspaces.js";
 
 export function createInfisicalClient(opts: InfisicalClientOptions) {

--- a/packages/jira-client/eslint.config.ts
+++ b/packages/jira-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/jira-client/package.json
+++ b/packages/jira-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/jira-client/src/index.ts
+++ b/packages/jira-client/src/index.ts
@@ -6,8 +6,8 @@ import { projects } from "./projects.js";
 import { transitions } from "./transitions.js";
 import { versions } from "./versions.js";
 
-export type * from "./types.js";
 export type { IssueLinkResult } from "./links.js";
+export type * from "./types.js";
 
 export type { issues, links, projects, transitions, versions };
 

--- a/packages/jira-client/src/issues.ts
+++ b/packages/jira-client/src/issues.ts
@@ -1,4 +1,5 @@
 import { type RestClient } from "@theholocron/http-client";
+
 import type {
 	JiraIssue,
 	JiraIssueFields,

--- a/packages/jira-client/src/links.ts
+++ b/packages/jira-client/src/links.ts
@@ -1,4 +1,5 @@
 import { ProviderApiError, type RestClient } from "@theholocron/http-client";
+
 import type { JiraIssueLinkType } from "./types.js";
 
 export interface IssueLinkResult {

--- a/packages/jira-client/src/projects.ts
+++ b/packages/jira-client/src/projects.ts
@@ -1,4 +1,5 @@
 import { type RestClient } from "@theholocron/http-client";
+
 import type { JiraProject } from "./types.js";
 
 export function projects(client: RestClient) {

--- a/packages/jira-client/src/transitions.ts
+++ b/packages/jira-client/src/transitions.ts
@@ -1,4 +1,5 @@
 import { type RestClient } from "@theholocron/http-client";
+
 import type {
 	JiraIssueFields,
 	JiraResolution,

--- a/packages/jira-client/src/versions.ts
+++ b/packages/jira-client/src/versions.ts
@@ -1,4 +1,5 @@
 import { type RestClient } from "@theholocron/http-client";
+
 import type { JiraVersion } from "./types.js";
 
 export function versions(client: RestClient) {

--- a/packages/neon-client/eslint.config.ts
+++ b/packages/neon-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/neon-client/package.json
+++ b/packages/neon-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/neon-client/src/__tests__/branches.test.ts
+++ b/packages/neon-client/src/__tests__/branches.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createNeonClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/neon-client/src/__tests__/client.test.ts
+++ b/packages/neon-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createNeonClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/neon-client/src/__tests__/connection.test.ts
+++ b/packages/neon-client/src/__tests__/connection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createNeonClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/neon-client/src/__tests__/databases.test.ts
+++ b/packages/neon-client/src/__tests__/databases.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createNeonClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/neon-client/src/__tests__/users.test.ts
+++ b/packages/neon-client/src/__tests__/users.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createNeonClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/neon-client/src/index.ts
+++ b/packages/neon-client/src/index.ts
@@ -1,16 +1,14 @@
-import { createNeonRestClient, type NeonClientOptions } from "./utils.js";
 import { branches } from "./branches/branches.js";
 import { connection } from "./connection/connection.js";
 import { databases } from "./databases/databases.js";
 import { users } from "./users/users.js";
-
-export type { NeonClientOptions } from "./utils.js";
+import { createNeonRestClient, type NeonClientOptions } from "./utils.js";
 
 export type {
+	CreateNeonBranchInput,
 	NeonBranch,
 	NeonBranchesResponse,
 	NeonBranchResponse,
-	CreateNeonBranchInput,
 } from "./branches/branches.js";
 export type {
 	NeonConnectionUriParams,
@@ -21,6 +19,7 @@ export type {
 	NeonDatabasesResponse,
 } from "./databases/databases.js";
 export type { NeonMe } from "./users/users.js";
+export type { NeonClientOptions } from "./utils.js";
 
 export function createNeonClient(opts: NeonClientOptions) {
 	const rest = createNeonRestClient(opts);

--- a/packages/postman-client/eslint.config.ts
+++ b/packages/postman-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/postman-client/package.json
+++ b/packages/postman-client/package.json
@@ -45,6 +45,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/postman-client/src/__tests__/client.test.ts
+++ b/packages/postman-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createPostmanClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/postman-client/src/__tests__/resources.test.ts
+++ b/packages/postman-client/src/__tests__/resources.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createPostmanClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/postman-client/src/import/import.ts
+++ b/packages/postman-client/src/import/import.ts
@@ -1,5 +1,5 @@
-import type { RestClient } from "../utils.js";
 import type { PostmanCollection } from "../collections/collections.js";
+import type { RestClient } from "../utils.js";
 
 export interface PostmanImportOpenApiResponse {
 	collections: PostmanCollection[];

--- a/packages/postman-client/src/index.ts
+++ b/packages/postman-client/src/index.ts
@@ -1,13 +1,10 @@
-import { createPostmanRestClient, type PostmanClientOptions } from "./utils.js";
 import { collections } from "./collections/collections.js";
 import { environments } from "./environments/environments.js";
 import { importApi } from "./import/import.js";
 import { me } from "./me/me.js";
 import { specs } from "./specs/specs.js";
+import { createPostmanRestClient, type PostmanClientOptions } from "./utils.js";
 import { workspaces } from "./workspaces/workspaces.js";
-
-export type { PostmanClientOptions } from "./utils.js";
-export { PostmanPlanLimitError, detectPlanLimit } from "./errors.js";
 
 export type {
 	PostmanCollection,
@@ -15,16 +12,18 @@ export type {
 } from "./collections/collections.js";
 export type {
 	PostmanEnvironment,
-	PostmanEnvironmentsResponse,
 	PostmanEnvironmentResponse,
+	PostmanEnvironmentsResponse,
 } from "./environments/environments.js";
+export { detectPlanLimit,PostmanPlanLimitError } from "./errors.js";
 export type { PostmanImportOpenApiResponse } from "./import/import.js";
-export type { PostmanUser, PostmanMeResponse } from "./me/me.js";
+export type { PostmanMeResponse,PostmanUser } from "./me/me.js";
 export type {
+	PostmanCreateSpecInput,
 	PostmanSpec,
 	PostmanSpecsResponse,
-	PostmanCreateSpecInput,
 } from "./specs/specs.js";
+export type { PostmanClientOptions } from "./utils.js";
 export type {
 	PostmanWorkspace,
 	PostmanWorkspacesResponse,

--- a/packages/postman-client/src/index.ts
+++ b/packages/postman-client/src/index.ts
@@ -15,9 +15,9 @@ export type {
 	PostmanEnvironmentResponse,
 	PostmanEnvironmentsResponse,
 } from "./environments/environments.js";
-export { detectPlanLimit,PostmanPlanLimitError } from "./errors.js";
+export { detectPlanLimit, PostmanPlanLimitError } from "./errors.js";
 export type { PostmanImportOpenApiResponse } from "./import/import.js";
-export type { PostmanMeResponse,PostmanUser } from "./me/me.js";
+export type { PostmanMeResponse, PostmanUser } from "./me/me.js";
 export type {
 	PostmanCreateSpecInput,
 	PostmanSpec,

--- a/packages/postman-client/src/utils.ts
+++ b/packages/postman-client/src/utils.ts
@@ -4,7 +4,7 @@ import {
 	type RestClient,
 } from "@theholocron/http-client";
 
-import { PostmanPlanLimitError, detectPlanLimit } from "./errors.js";
+import { detectPlanLimit,PostmanPlanLimitError } from "./errors.js";
 
 export type { RestClient };
 

--- a/packages/postman-client/src/utils.ts
+++ b/packages/postman-client/src/utils.ts
@@ -4,7 +4,7 @@ import {
 	type RestClient,
 } from "@theholocron/http-client";
 
-import { detectPlanLimit,PostmanPlanLimitError } from "./errors.js";
+import { detectPlanLimit, PostmanPlanLimitError } from "./errors.js";
 
 export type { RestClient };
 

--- a/packages/vercel-client/eslint.config.ts
+++ b/packages/vercel-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/vercel-client/package.json
+++ b/packages/vercel-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/vercel-client/src/__tests__/client.test.ts
+++ b/packages/vercel-client/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createVercelClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/vercel-client/src/__tests__/resources.test.ts
+++ b/packages/vercel-client/src/__tests__/resources.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createVercelClient } from "../index.js";
 import { stubFetch } from "./helpers.js";
 

--- a/packages/vercel-client/src/index.ts
+++ b/packages/vercel-client/src/index.ts
@@ -1,10 +1,8 @@
-import { createVercelRestClient, type VercelClientOptions } from "./utils.js";
 import { deployments } from "./deployments/deployments.js";
 import { env } from "./env/env.js";
 import { projects } from "./projects/projects.js";
 import { user } from "./user/user.js";
-
-export type { VercelClientOptions } from "./utils.js";
+import { createVercelRestClient, type VercelClientOptions } from "./utils.js";
 
 export type {
 	VercelDeployment,
@@ -18,13 +16,14 @@ export type {
 	VercelEnvVarsResponse,
 } from "./env/env.js";
 export type {
+	VercelCreateProjectInput,
 	VercelProject,
 	VercelProjectLink,
 	VercelProjectsResponse,
-	VercelCreateProjectInput,
 	VercelUpdateProjectInput,
 } from "./projects/projects.js";
 export type { VercelUser, VercelUserResponse } from "./user/user.js";
+export type { VercelClientOptions } from "./utils.js";
 
 export function createVercelClient(opts: VercelClientOptions) {
 	const rest = createVercelRestClient(opts);

--- a/packages/zendesk-client/eslint.config.ts
+++ b/packages/zendesk-client/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -46,6 +46,7 @@
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -1,10 +1,10 @@
-import { createZendeskRestClient, type ZendeskClientOptions } from "./utils.js";
 import { activities } from "./activities/activities.js";
 import { search } from "./search/search.js";
 import { status } from "./status/status.js";
 import { comments } from "./tickets/comments.js";
 import { fields } from "./tickets/fields.js";
 import { tickets } from "./tickets/tickets.js";
+import { createZendeskRestClient, type ZendeskClientOptions } from "./utils.js";
 
 export { createToken, type ZendeskClientOptions } from "./utils.js";
 
@@ -21,9 +21,9 @@ export type * from "./user/index.js";
 // ── Mocks ────────────────────────────────────────────────────────────────────
 export { mockActivity, mockActivityResponse } from "./activities/index.js";
 export {
+	mockAttachment,
 	mockImage,
 	mockThumbnail,
-	mockAttachment,
 } from "./attachments/index.js";
 export { mockGroup } from "./group/index.js";
 export {
@@ -32,10 +32,10 @@ export {
 	mockSearchResponseUsers,
 } from "./search/index.js";
 export {
-	mockDefaultStatus,
 	mockCustomStatus,
 	mockCustomStatusesResponse,
 	mockCustomStatusResponse,
+	mockDefaultStatus,
 } from "./status/index.js";
 export {
 	mockComment,
@@ -43,15 +43,15 @@ export {
 	mockCustomField1,
 	mockCustomField2,
 	mockCustomFields,
-	mockTicketMetric,
-	mockTicketField,
-	mockTicketFieldsResponse,
-	mockTicketFieldResponse,
-	mockVia,
 	mockMetadata,
 	mockTicket,
-	mockTicketsResponse,
+	mockTicketField,
+	mockTicketFieldResponse,
+	mockTicketFieldsResponse,
+	mockTicketMetric,
 	mockTicketResponse,
+	mockTicketsResponse,
+	mockVia,
 } from "./tickets/index.js";
 export { mockUser } from "./user/index.js";
 

--- a/packages/zendesk-client/src/search/search.types.ts
+++ b/packages/zendesk-client/src/search/search.types.ts
@@ -1,6 +1,6 @@
-import type { IAPIResponse } from "../types.js";
 import type { IGroup } from "../group/group.types.js";
 import type { ITicket } from "../tickets/tickets.types.js";
+import type { IAPIResponse } from "../types.js";
 import type { IUser } from "../user/user.types.js";
 
 export interface ISearchResponse extends IAPIResponse {

--- a/packages/zendesk-client/src/status/status.ts
+++ b/packages/zendesk-client/src/status/status.ts
@@ -2,8 +2,8 @@ import type { RestClient } from "@theholocron/http-client";
 
 import type {
 	ICustomStatus,
-	ICustomStatusResponse,
 	ICustomStatusesResponse,
+	ICustomStatusResponse,
 } from "./status.types.js";
 
 const PATH = "/api/v2/custom_statuses";

--- a/packages/zendesk-client/src/tickets/index.ts
+++ b/packages/zendesk-client/src/tickets/index.ts
@@ -1,11 +1,11 @@
 export { comments } from "./comments.js";
-export { fields } from "./fields.js";
-export { tickets } from "./tickets.js";
 export * from "./comments.mocks.js";
 export * from "./comments.types.js";
+export { fields } from "./fields.js";
 export * from "./fields.mocks.js";
 export * from "./fields.types.js";
 export * from "./metrics.mocks.js";
 export * from "./metrics.types.js";
+export { tickets } from "./tickets.js";
 export * from "./tickets.mocks.js";
 export * from "./tickets.types.js";

--- a/packages/zendesk-client/src/tickets/tickets.mocks.ts
+++ b/packages/zendesk-client/src/tickets/tickets.mocks.ts
@@ -1,11 +1,11 @@
+import { mockCustomFields } from "./fields.mocks.js";
 import type {
+	IMetadata,
 	ITicket,
+	IVia,
 	TTicketResponse,
 	TTicketsResponse,
-	IVia,
-	IMetadata,
 } from "./tickets.types.js";
-import { mockCustomFields } from "./fields.mocks.js";
 
 export const mockVia: IVia = {
 	channel: "web",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^7.4.1
       version: 7.4.1
     '@theholocron/eslint-config':
-      specifier: ^7.4.1
-      version: 7.4.1
+      specifier: ^7.6.0
+      version: 7.6.0
     '@theholocron/http-client':
       specifier: ^0.11.5
       version: 0.11.5
@@ -48,6 +48,9 @@ catalogs:
     eslint-plugin-n:
       specifier: ^18.2.2
       version: 18.2.2
+    eslint-plugin-simple-import-sort:
+      specifier: ^14.0.0
+      version: 14.0.0
     globals:
       specifier: ^17.7.0
       version: 17.7.0
@@ -107,7 +110,7 @@ importers:
         version: 7.4.1(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:holocron
         version: 7.4.1(@theholocron/cli@2.1.1(vitest@4.1.10))
@@ -171,7 +174,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -196,6 +199,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -217,7 +223,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -242,6 +248,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -263,7 +272,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -288,6 +297,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -309,7 +321,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -334,6 +346,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -364,7 +379,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -392,6 +407,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -409,7 +427,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -434,6 +452,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -455,7 +476,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -480,6 +501,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -501,7 +525,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -526,6 +550,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -547,7 +574,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -572,6 +599,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -593,7 +623,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -618,6 +648,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -639,7 +672,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -664,6 +697,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -685,7 +721,7 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 7.4.1(typescript@5.9.3)
@@ -710,6 +746,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -1765,8 +1804,8 @@ packages:
       '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^21.2.0
 
-  '@theholocron/eslint-config@7.4.1':
-    resolution: {integrity: sha512-TmJ2DxzEqW5blgaIQ+aaADV6MBak45G9ZLIz70dR+/PjAGsjy1Q+upnsQ81bAvKSNy5iNhiV2Di+mH6AEBbW9g==}
+  '@theholocron/eslint-config@7.6.0':
+    resolution: {integrity: sha512-k1Xws/GxadHgcfaHhgbyluHT/53cuGtgLegHErOTwaja4Wl4L6eCwcveA2sOn3Yg39oJYIRsdhC8aH0pialEwg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@eslint/js': ^10
@@ -1776,6 +1815,7 @@ packages:
       eslint-plugin-cypress: ^6
       eslint-plugin-n: ^18
       eslint-plugin-react: ^7
+      eslint-plugin-simple-import-sort: ^14
       eslint-plugin-storybook: ^10
       globals: ^17
       typescript-eslint: ^8
@@ -2656,6 +2696,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  eslint-plugin-simple-import-sort@14.0.0:
+    resolution: {integrity: sha512-NUJO0+XFCkk+o5EsAJruTgnfMEpeWrPWeJS15UVF60GgXmqz1BJ9/3hzlvG7lkL8Bubzos5cCLptThbFfPnSMQ==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -5283,10 +5328,11 @@ snapshots:
       '@commitlint/cli': 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@5.9.3)
       '@commitlint/config-conventional': 21.2.0
 
-  '@theholocron/eslint-config@7.4.1(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.7.0(jiti@2.7.0))
       eslint: 10.7.0(jiti@2.7.0)
+      eslint-plugin-simple-import-sort: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals: 17.7.0
       typescript-eslint: 8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
     optionalDependencies:
@@ -6052,6 +6098,10 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       typescript: 5.9.3
+
+  eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.7.0(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,8 @@ packages:
 # Shared dep versions used across packages.
 catalog:
   '@theholocron/commitlint-config': ^7.4.1
-  '@theholocron/eslint-config': ^7.4.1
+  '@theholocron/eslint-config': ^7.6.0
+  eslint-plugin-simple-import-sort: ^14.0.0
   '@theholocron/http-client': ^0.11.5
   '@theholocron/lint-staged-config': ^7.4.1
   '@theholocron/prettier-config': ^7.4.1


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/eslint-config` from `^7.4.1` to `^7.6.0`
- Adds `eslint-plugin-simple-import-sort@^14` to the catalog and to each package's devDependencies (new required peer dep introduced in 7.6.0)
- Runs `eslint --fix` to auto-sort all existing import and export statements

## Why

`@theholocron/eslint-config@7.6.0` ([configs#298](https://github.com/theholocron/configs/pull/298)) adds `eslint-plugin-simple-import-sort` to the `base()` config, enforcing consistent import ordering across all repos. This PR applies the bump and resolves all pre-existing ordering violations via autofix.