### PR TITLE
fix: add id-token: write to test workflow for Codecov OIDC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

The reusable `test.yml` in `.github` (sync #66) switched Codecov to OIDC (`use_oidc: true`), requiring `id-token: write`. GitHub does not inherit this permission through `secrets: inherit` — it must be explicit in the calling workflow. Missing permission caused `startup_failure` with no jobs starting.

- Adds `id-token: write` to `permissions` in `.github/workflows/test.yml`

Root cause fixed in the caller template: theholocron/holocron#249. This PR unblocks CI immediately; the template fix propagates to all repos via the next `holocron setup` sync.

## Test plan

- [ ] Test workflow passes (no more `startup_failure`)