### PR TITLE
feat: add clients-docs and github-client-docs content packages

### DIFF
--- a/packages/clients-docs/README.md
+++ b/packages/clients-docs/README.md
@@ -1,0 +1,24 @@
+# @theholocron/clients-docs
+
+Documentation content package for the [`@theholocron/clients`](https://github.com/theholocron/clients) monorepo.
+
+This package publishes Markdown content and a `DocsConfig` object consumed by the
+[`theholocron.github.io`](https://github.com/theholocron/theholocron.github.io) aggregator site
+and any per-repo Starlight shell that links it via `workspace:*`.
+
+## Structure
+
+```
+content/        Markdown pages
+dist/           Compiled DocsConfig (generated — do not edit)
+src/index.ts    DocsConfig source
+```
+
+## Usage
+
+```ts
+import config from "@theholocron/clients-docs";
+
+console.log(config.slug);    // "clients"
+console.log(config.sidebar); // sidebar tree for Starlight
+```

--- a/packages/clients-docs/README.md
+++ b/packages/clients-docs/README.md
@@ -19,6 +19,6 @@ src/index.ts    DocsConfig source
 ```ts
 import config from "@theholocron/clients-docs";
 
-console.log(config.slug);    // "clients"
+console.log(config.slug); // "clients"
 console.log(config.sidebar); // sidebar tree for Starlight
 ```

--- a/packages/clients-docs/content/index.md
+++ b/packages/clients-docs/content/index.md
@@ -9,20 +9,20 @@ resolution, base URL construction, and normalised error responses.
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| [`@theholocron/clerk-client`](./clerk) | Clerk user management |
-| [`@theholocron/confluence-client`](./confluence) | Confluence Cloud pages & spaces |
-| [`@theholocron/doppler-client`](./doppler) | Doppler secrets manager |
-| [`@theholocron/github-client`](./github) | GitHub REST API |
-| [`@theholocron/google-client`](./google) | Google Workspace APIs |
-| [`@theholocron/http-client`](./http) | Shared HTTP primitives (base layer) |
-| [`@theholocron/infisical-client`](./infisical) | Infisical secrets manager |
-| [`@theholocron/jira-client`](./jira) | Jira Cloud issues & projects |
-| [`@theholocron/neon-client`](./neon) | Neon serverless Postgres |
-| [`@theholocron/postman-client`](./postman) | Postman collections & environments |
-| [`@theholocron/vercel-client`](./vercel) | Vercel deployments & projects |
-| [`@theholocron/zendesk-client`](./zendesk) | Zendesk tickets & users |
+| Package                                          | Description                         |
+| ------------------------------------------------ | ----------------------------------- |
+| [`@theholocron/clerk-client`](./clerk)           | Clerk user management               |
+| [`@theholocron/confluence-client`](./confluence) | Confluence Cloud pages & spaces     |
+| [`@theholocron/doppler-client`](./doppler)       | Doppler secrets manager             |
+| [`@theholocron/github-client`](./github)         | GitHub REST API                     |
+| [`@theholocron/google-client`](./google)         | Google Workspace APIs               |
+| [`@theholocron/http-client`](./http)             | Shared HTTP primitives (base layer) |
+| [`@theholocron/infisical-client`](./infisical)   | Infisical secrets manager           |
+| [`@theholocron/jira-client`](./jira)             | Jira Cloud issues & projects        |
+| [`@theholocron/neon-client`](./neon)             | Neon serverless Postgres            |
+| [`@theholocron/postman-client`](./postman)       | Postman collections & environments  |
+| [`@theholocron/vercel-client`](./vercel)         | Vercel deployments & projects       |
+| [`@theholocron/zendesk-client`](./zendesk)       | Zendesk tickets & users             |
 
 ## Install
 

--- a/packages/clients-docs/content/index.md
+++ b/packages/clients-docs/content/index.md
@@ -1,0 +1,36 @@
+---
+title: Clients
+description: TypeScript HTTP clients for third-party APIs, built on @theholocron/http-client.
+---
+
+`@theholocron/clients` is a pnpm monorepo of typed HTTP clients for popular third-party APIs.
+Every client wraps `@theholocron/http-client` — a thin fetch-based layer that handles token
+resolution, base URL construction, and normalised error responses.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@theholocron/clerk-client`](./clerk) | Clerk user management |
+| [`@theholocron/confluence-client`](./confluence) | Confluence Cloud pages & spaces |
+| [`@theholocron/doppler-client`](./doppler) | Doppler secrets manager |
+| [`@theholocron/github-client`](./github) | GitHub REST API |
+| [`@theholocron/google-client`](./google) | Google Workspace APIs |
+| [`@theholocron/http-client`](./http) | Shared HTTP primitives (base layer) |
+| [`@theholocron/infisical-client`](./infisical) | Infisical secrets manager |
+| [`@theholocron/jira-client`](./jira) | Jira Cloud issues & projects |
+| [`@theholocron/neon-client`](./neon) | Neon serverless Postgres |
+| [`@theholocron/postman-client`](./postman) | Postman collections & environments |
+| [`@theholocron/vercel-client`](./vercel) | Vercel deployments & projects |
+| [`@theholocron/zendesk-client`](./zendesk) | Zendesk tickets & users |
+
+## Install
+
+Each package is published independently to npm:
+
+```bash
+npm i @theholocron/github-client
+```
+
+All packages follow the same lockstep versioning — see the
+[releases page](https://github.com/theholocron/clients/releases) for the current version.

--- a/packages/clients-docs/eslint.config.ts
+++ b/packages/clients-docs/eslint.config.ts
@@ -1,0 +1,14 @@
+import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
+
+const config = [
+	...library(),
+	{
+		rules: {
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+] satisfies Linter.Config[];
+
+export default config;

--- a/packages/clients-docs/package.json
+++ b/packages/clients-docs/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@theholocron/clients-docs",
+  "version": "1.3.4",
+  "description": "Documentation content for the @theholocron/clients monorepo",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/clients-docs#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/clients-docs"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "keywords": [
+    "docs",
+    "documentation",
+    "content",
+    "typescript",
+    "http-client",
+    "api"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "content",
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/clients-docs/src/index.ts
+++ b/packages/clients-docs/src/index.ts
@@ -1,0 +1,44 @@
+export interface SidebarLink {
+	label: string;
+	slug: string;
+}
+
+export interface SidebarGroup {
+	label: string;
+	items: Array<SidebarLink | SidebarGroup>;
+}
+
+export interface DocsConfig {
+	slug: string;
+	parent: string | null;
+	name: string;
+	sidebar: Array<SidebarLink | SidebarGroup>;
+}
+
+const config: DocsConfig = {
+	slug: "clients",
+	parent: null,
+	name: "Clients",
+	sidebar: [
+		{ label: "Overview", slug: "clients" },
+		{
+			label: "Packages",
+			items: [
+				{ label: "Clerk", slug: "clients/clerk" },
+				{ label: "Confluence", slug: "clients/confluence" },
+				{ label: "Doppler", slug: "clients/doppler" },
+				{ label: "GitHub", slug: "clients/github" },
+				{ label: "Google", slug: "clients/google" },
+				{ label: "HTTP (base)", slug: "clients/http" },
+				{ label: "Infisical", slug: "clients/infisical" },
+				{ label: "Jira", slug: "clients/jira" },
+				{ label: "Neon", slug: "clients/neon" },
+				{ label: "Postman", slug: "clients/postman" },
+				{ label: "Vercel", slug: "clients/vercel" },
+				{ label: "Zendesk", slug: "clients/zendesk" },
+			],
+		},
+	],
+};
+
+export default config;

--- a/packages/clients-docs/tsconfig.json
+++ b/packages/clients-docs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/clients-docs/tsdown.config.ts
+++ b/packages/clients-docs/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/github-client-docs/README.md
+++ b/packages/github-client-docs/README.md
@@ -1,0 +1,25 @@
+# @theholocron/github-client-docs
+
+Documentation content package for [`@theholocron/github-client`](https://github.com/theholocron/clients/tree/main/packages/github-client).
+
+This package publishes Markdown content and a `DocsConfig` object consumed by the
+[`theholocron.github.io`](https://github.com/theholocron/theholocron.github.io) aggregator site
+and any per-repo Starlight shell that links it via `workspace:*`.
+
+## Structure
+
+```
+content/        Markdown pages
+dist/           Compiled DocsConfig (generated — do not edit)
+src/index.ts    DocsConfig source
+```
+
+## Usage
+
+```ts
+import config from "@theholocron/github-client-docs";
+
+console.log(config.slug);    // "clients/github"
+console.log(config.parent);  // "clients"
+console.log(config.sidebar); // sidebar tree for Starlight
+```

--- a/packages/github-client-docs/README.md
+++ b/packages/github-client-docs/README.md
@@ -19,7 +19,7 @@ src/index.ts    DocsConfig source
 ```ts
 import config from "@theholocron/github-client-docs";
 
-console.log(config.slug);    // "clients/github"
-console.log(config.parent);  // "clients"
+console.log(config.slug); // "clients/github"
+console.log(config.parent); // "clients"
 console.log(config.sidebar); // sidebar tree for Starlight
 ```

--- a/packages/github-client-docs/content/index.md
+++ b/packages/github-client-docs/content/index.md
@@ -24,19 +24,19 @@ const labels = await client.labels.listLabels("owner/name");
 
 ## Namespaces
 
-| Namespace | Methods |
-|-----------|---------|
-| `branches` | `protectBranch` |
-| `environments` | `listEnvironments`, `upsertEnvironment`, `deleteEnvironment` |
-| `git` | `getRef`, `getCommit`, `getTree`, `getContents`, `createBlob`, `createTree`, `createCommit`, `createRef`, `updateRef`, `createPull` |
-| `issues` | `listIssues`, `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones` |
-| `labels` | `listLabels`, `createLabel`, `updateLabel`, `deleteLabel` |
-| `properties` | `setProperties` |
-| `repos` | `getRepo`, `updateRepo`, `getContents` |
-| `rulesets` | `listRulesets`, `createRuleset`, `updateRuleset` |
-| `secrets` | `listSecrets`, `getPublicKey`, `putSecret`, `deleteSecret` |
-| `security` | `enableVulnerabilityAlerts`, `enableAutomatedSecurityFixes`, `enableSecretScanning`, `enablePrivateVulnerabilityReporting`, `enableDependencyGraph`, `enableCodeScanning`, `disableDefaultCodeScanning` |
-| `teams` | (see package) |
-| `topics` | `setTopics` |
-| `user` | `getCurrentUser` |
-| `workflows` | `listRuns`, `getRun` |
+| Namespace      | Methods                                                                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `branches`     | `protectBranch`                                                                                                                                                                                         |
+| `environments` | `listEnvironments`, `upsertEnvironment`, `deleteEnvironment`                                                                                                                                            |
+| `git`          | `getRef`, `getCommit`, `getTree`, `getContents`, `createBlob`, `createTree`, `createCommit`, `createRef`, `updateRef`, `createPull`                                                                     |
+| `issues`       | `listIssues`, `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones`                                                                                   |
+| `labels`       | `listLabels`, `createLabel`, `updateLabel`, `deleteLabel`                                                                                                                                               |
+| `properties`   | `setProperties`                                                                                                                                                                                         |
+| `repos`        | `getRepo`, `updateRepo`, `getContents`                                                                                                                                                                  |
+| `rulesets`     | `listRulesets`, `createRuleset`, `updateRuleset`                                                                                                                                                        |
+| `secrets`      | `listSecrets`, `getPublicKey`, `putSecret`, `deleteSecret`                                                                                                                                              |
+| `security`     | `enableVulnerabilityAlerts`, `enableAutomatedSecurityFixes`, `enableSecretScanning`, `enablePrivateVulnerabilityReporting`, `enableDependencyGraph`, `enableCodeScanning`, `disableDefaultCodeScanning` |
+| `teams`        | (see package)                                                                                                                                                                                           |
+| `topics`       | `setTopics`                                                                                                                                                                                             |
+| `user`         | `getCurrentUser`                                                                                                                                                                                        |
+| `workflows`    | `listRuns`, `getRun`                                                                                                                                                                                    |

--- a/packages/github-client-docs/content/index.md
+++ b/packages/github-client-docs/content/index.md
@@ -1,0 +1,42 @@
+---
+title: GitHub Client
+description: TypeScript client for the GitHub REST API, built on @theholocron/http-client.
+---
+
+`@theholocron/github-client` is a typed wrapper around the GitHub REST API.
+
+## Install
+
+```bash
+npm i @theholocron/github-client
+```
+
+## Usage
+
+```ts
+import { createGitHubClient } from "@theholocron/github-client";
+
+const client = createGitHubClient({ token: process.env.GITHUB_TOKEN });
+
+const repo = await client.repos.getRepo("owner/name");
+const labels = await client.labels.listLabels("owner/name");
+```
+
+## Namespaces
+
+| Namespace | Methods |
+|-----------|---------|
+| `branches` | `protectBranch` |
+| `environments` | `listEnvironments`, `upsertEnvironment`, `deleteEnvironment` |
+| `git` | `getRef`, `getCommit`, `getTree`, `getContents`, `createBlob`, `createTree`, `createCommit`, `createRef`, `updateRef`, `createPull` |
+| `issues` | `listIssues`, `getIssue`, `createIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createComment`, `listMilestones` |
+| `labels` | `listLabels`, `createLabel`, `updateLabel`, `deleteLabel` |
+| `properties` | `setProperties` |
+| `repos` | `getRepo`, `updateRepo`, `getContents` |
+| `rulesets` | `listRulesets`, `createRuleset`, `updateRuleset` |
+| `secrets` | `listSecrets`, `getPublicKey`, `putSecret`, `deleteSecret` |
+| `security` | `enableVulnerabilityAlerts`, `enableAutomatedSecurityFixes`, `enableSecretScanning`, `enablePrivateVulnerabilityReporting`, `enableDependencyGraph`, `enableCodeScanning`, `disableDefaultCodeScanning` |
+| `teams` | (see package) |
+| `topics` | `setTopics` |
+| `user` | `getCurrentUser` |
+| `workflows` | `listRuns`, `getRun` |

--- a/packages/github-client-docs/eslint.config.ts
+++ b/packages/github-client-docs/eslint.config.ts
@@ -1,0 +1,14 @@
+import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
+
+const config = [
+	...library(),
+	{
+		rules: {
+			"n/no-unpublished-import": "off",
+		},
+	},
+	{ ignores: ["dist/**", "coverage/**"] },
+] satisfies Linter.Config[];
+
+export default config;

--- a/packages/github-client-docs/package.json
+++ b/packages/github-client-docs/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@theholocron/github-client-docs",
+  "version": "1.3.4",
+  "description": "Documentation content for @theholocron/github-client",
+  "homepage": "https://github.com/theholocron/clients/tree/main/packages/github-client-docs#readme",
+  "bugs": "https://github.com/theholocron/clients/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/clients.git",
+    "directory": "packages/github-client-docs"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "keywords": [
+    "github",
+    "git",
+    "vcs",
+    "docs",
+    "documentation",
+    "content",
+    "typescript",
+    "http-client",
+    "api"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@theholocron/eslint-config": "catalog:",
+    "@theholocron/tsconfig": "catalog:",
+    "@theholocron/tsdown-config": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "content",
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "releases": "https://github.com/theholocron/clients/releases",
+  "wiki": "https://github.com/theholocron/clients/wiki"
+}

--- a/packages/github-client-docs/src/index.ts
+++ b/packages/github-client-docs/src/index.ts
@@ -1,0 +1,25 @@
+export interface SidebarLink {
+	label: string;
+	slug: string;
+}
+
+export interface SidebarGroup {
+	label: string;
+	items: Array<SidebarLink | SidebarGroup>;
+}
+
+export interface DocsConfig {
+	slug: string;
+	parent: string;
+	name: string;
+	sidebar: Array<SidebarLink | SidebarGroup>;
+}
+
+const config: DocsConfig = {
+	slug: "clients/github",
+	parent: "clients",
+	name: "GitHub Client",
+	sidebar: [{ label: "Overview", slug: "clients/github" }],
+};
+
+export default config;

--- a/packages/github-client-docs/tsconfig.json
+++ b/packages/github-client-docs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/github-client-docs/tsdown.config.ts
+++ b/packages/github-client-docs/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,39 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/clients-docs:
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 7.4.1(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 7.4.1(tsdown@0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.1
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.7.0)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/confluence-client:
     dependencies:
       '@theholocron/http-client':
@@ -361,6 +394,39 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/github-client-docs:
+    devDependencies:
+      '@theholocron/eslint-config':
+        specifier: 'catalog:'
+        version: 7.6.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 7.4.1(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: 'catalog:'
+        version: 7.4.1(tsdown@0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.1
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.7.0)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
+      globals:
+        specifier: 'catalog:'
+        version: 17.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/google-client:
     dependencies:

--- a/release.config.ts
+++ b/release.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/confluence-client','packages/doppler-client','packages/github-client','packages/google-client','packages/http-client','packages/infisical-client','packages/jira-client','packages/neon-client','packages/postman-client','packages/vercel-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/clerk-client','packages/clients-docs','packages/confluence-client','packages/doppler-client','packages/github-client','packages/github-client-docs','packages/google-client','packages/http-client','packages/infisical-client','packages/jira-client','packages/neon-client','packages/postman-client','packages/vercel-client','packages/zendesk-client'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
## Summary

- Adds `packages/clients-docs/` → `@theholocron/clients-docs` — umbrella overview content for the monorepo
- Adds `packages/github-client-docs/` → `@theholocron/github-client-docs` — per-client docs for `@theholocron/github-client`
- Wires both packages into `release.config.ts` `prepareCmd` (alphabetical order) so they advance in lockstep with all other packages

This is **step 2** of the federated docs architecture. Each package follows the same `tsdown` + lockstep-versioning pattern as the existing client packages:

- `src/index.ts` — exports `DocsConfig` type and a default config object (`{ slug, parent, name, sidebar }`)
- `content/index.md` — initial Markdown content page
- `dist/` — compiled config (tsdown → `.mjs` + `.d.mts`); published alongside `content/`

No Astro dependency in these packages. The consuming Starlight site (step 3, `docs/` shell) will import the config via `workspace:*` and pull content from `content/`.

## Test plan

- [x] `pnpm --filter @theholocron/clients-docs build` — clean
- [x] `pnpm --filter @theholocron/github-client-docs build` — clean
- [x] `pnpm --filter @theholocron/clients-docs typecheck` — clean
- [x] `pnpm --filter @theholocron/github-client-docs typecheck` — clean
- [x] `pnpm --filter @theholocron/clients-docs lint` — clean
- [x] `pnpm --filter @theholocron/github-client-docs lint` — clean
- [x] `pnpm install` resolves 15 workspace projects (was 13)