### PR TITLE
ci: add GitHub Pages deploy workflow for docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - packages/clients-docs/**
+      - packages/github-client-docs/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - name: Build content packages
+        run: pnpm turbo build --filter=@theholocron/clients-docs --filter=@theholocron/github-client-docs
+
+      - name: Build docs site
+        run: pnpm --filter @theholocron/clients-site build
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        name: Upload pages artifact
+        with:
+          path: docs/dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        id: deployment
+        name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-docs.yml` to build and deploy the `docs/` Astro + Starlight site to GitHub Pages
- Triggers on push to `main` when docs-related paths change (`docs/**`, `packages/clients-docs/**`, `packages/github-client-docs/**`), plus `workflow_dispatch` for manual redeploys
- Build job runs `pnpm turbo build` for both content packages then `pnpm --filter @theholocron/clients-site build`; uploads `docs/dist` as the pages artifact
- Deploy job uses OIDC (`id-token: write`) with `cancel-in-progress: false` so in-flight deploys are never cancelled mid-flight
- All third-party actions pinned to commit SHAs

## Test plan

- [ ] Merge and confirm the workflow runs on the next push that touches `docs/` or either content package
- [ ] Verify the deployed site is live at `https://theholocron.github.io/clients/`
- [ ] Confirm `workflow_dispatch` trigger works for manual redeploys