### PR TITLE
fix: serialize packages array into release prepareCmd

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -19,7 +19,9 @@ const packages = [
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; packages.forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; " +
+			JSON.stringify(packages) +
+			".forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
## Summary

The `packages` variable introduced in the previous PR is defined in the TypeScript module scope, but `prepareCmd` runs as a separate `node -e` subprocess — it has no access to the outer scope. The command was failing with `ReferenceError: packages is not defined`.

Fix: use `JSON.stringify(packages)` to bake the array value into the command string at config-evaluation time. The subprocess sees the array literal directly, never the variable name.

## Before

```
node -e "...packages.forEach(p=>{...})"
        ^^^^^^^^ ReferenceError at runtime
```

## After

```
node -e '...["packages/clerk-client",...].forEach(p=>{...})'
```