### PR TITLE
fix: use single-quoted array in release prepareCmd to survive shell quoting

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -19,7 +19,9 @@ const packages = [
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; packages.forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; " +
+			JSON.stringify(packages) +
+			".forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},

--- a/release.config.ts
+++ b/release.config.ts
@@ -16,12 +16,11 @@ const packages = [
 	"packages/zendesk-client",
 ];
 
+const packageList = packages.map((p) => `'${p}'`).join(",");
+
 export default defineConfig({
 	exec: {
-		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; " +
-			JSON.stringify(packages) +
-			".forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+		prepareCmd: `node -e "const fs=require('fs'),v='\${nextRelease.version}'; [${packageList}].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});"`,
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
## Summary

The previous fix (#233) used `JSON.stringify(packages)` which produces double-quoted strings like `["packages/clerk-client",...]`. Inside `node -e "..."` those inner double quotes break the outer shell quoting — bash strips them so Node.js sees `packages/clerk-client` as a division expression (`packages` ÷ `clerk-client`), causing `ReferenceError: packages is not defined`.

Fix: build the array with single-quoted strings (`'packages/clerk-client',...`) using a template literal. Single quotes have no special meaning inside a double-quoted shell argument so they pass through intact.

## Generated command

```
node -e "const fs=require('fs'),v='1.5.1'; ['packages/clerk-client','packages/clients-docs',...].forEach(p=>{...});"
```