### PR TITLE
fix: remove github-client-docs references from deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,7 +6,6 @@ on: # yamllint disable-line rule:truthy
     paths:
       - docs/**
       - packages/clients-docs/**
-      - packages/github-client-docs/**
   workflow_dispatch:
 
 permissions:
@@ -30,7 +29,7 @@ jobs:
         name: Setup
 
       - name: Build content packages
-        run: pnpm turbo build --filter=@theholocron/clients-docs --filter=@theholocron/github-client-docs
+        run: pnpm turbo build --filter=@theholocron/clients-docs
 
       - name: Build docs site
         run: pnpm --filter @theholocron/clients-site build


### PR DESCRIPTION
## Summary

`@theholocron/github-client-docs` was removed in #232 (one docs package per repo), but `deploy-docs.yml` still referenced it in both the path trigger and the turbo build filter, causing the workflow to fail with `No package found with name '@theholocron/github-client-docs' in workspace`.