### PR TITLE
fix(docs): render markdown body and fix sidebar autogenerate

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -2,6 +2,17 @@ import { docsTheme } from "@theholocron/docs-theme";
 import clientsConfig from "@theholocron/clients-docs";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import { relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Starlight autogenerate matches filePaths relative to the Astro project root.
+// Our content lives outside docs/ so we compute the relative path so the
+// directory: value matches how the loader stores filePaths.
+const docsDir = fileURLToPath(new URL(".", import.meta.url));
+const contentDir = fileURLToPath(
+	new URL("../packages/clients-docs/content", import.meta.url),
+);
+const contentRelDir = relative(docsDir, contentDir);
 
 export default defineConfig({
 	site: "https://theholocron.github.io",
@@ -21,7 +32,7 @@ export default defineConfig({
 				{ label: "Overview", slug: "" },
 				{
 					label: "Packages",
-					items: [{ autogenerate: { directory: "." } }],
+					items: [{ autogenerate: { directory: contentRelDir } }],
 				},
 			],
 		}),

--- a/docs/src/loaders/workspace-docs.ts
+++ b/docs/src/loaders/workspace-docs.ts
@@ -1,10 +1,9 @@
 import type { Loader, LoaderContext } from "astro/loaders";
 import matter from "gray-matter";
-import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { readdir } from "node:fs/promises";
 import { extname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export interface WorkspaceDocsSource {
 	/** Absolute path to the content directory. */
@@ -60,12 +59,9 @@ export function workspaceDocsLoader(sources: WorkspaceDocsSource[]): Loader {
 			for (const { dir, slug: slugPrefix } of sources) {
 				for await (const absPath of walk(dir)) {
 					const id = computeId(absPath, dir, slugPrefix);
-					const raw = readFileSync(absPath, "utf-8");
+					const raw = await readFile(absPath, "utf-8");
 					const { data: frontmatter, content: body } = matter(raw);
-					const digest = createHash("sha256")
-						.update(raw)
-						.digest("hex")
-						.slice(0, 8);
+					const digest = ctx.generateDigest(raw);
 					// Astro requires filePath to be relative to the site root (no leading /)
 					const filePath = relative(siteRoot, absPath);
 					const data = await ctx.parseData({
@@ -73,7 +69,10 @@ export function workspaceDocsLoader(sources: WorkspaceDocsSource[]): Loader {
 						data: frontmatter,
 						filePath,
 					});
-					ctx.store.set({ id, data, body, filePath, digest });
+					const rendered = await ctx.renderMarkdown(body, {
+						fileURL: pathToFileURL(absPath),
+					});
+					ctx.store.set({ id, data, body, filePath, digest, rendered });
 					ctx.watcher?.add(absPath);
 				}
 			}

--- a/docs/src/loaders/workspace-docs.ts
+++ b/docs/src/loaders/workspace-docs.ts
@@ -72,7 +72,14 @@ export function workspaceDocsLoader(sources: WorkspaceDocsSource[]): Loader {
 					const rendered = await ctx.renderMarkdown(body, {
 						fileURL: pathToFileURL(absPath),
 					});
-					ctx.store.set({ id, data, body, filePath, digest, rendered });
+					ctx.store.set({
+						id,
+						data,
+						body,
+						filePath,
+						digest,
+						rendered,
+					});
 					ctx.watcher?.add(absPath);
 				}
 			}

--- a/packages/clients-docs/content/index.md
+++ b/packages/clients-docs/content/index.md
@@ -1,6 +1,8 @@
 ---
 title: Clients
 description: TypeScript HTTP clients for third-party APIs, built on @theholocron/http-client.
+sidebar:
+  hidden: true
 ---
 
 `@theholocron/clients` is a pnpm monorepo of typed HTTP clients for popular third-party APIs.


### PR DESCRIPTION
## Summary

- **Empty body**: The `workspaceDocsLoader` was storing raw `body` but never calling `ctx.renderMarkdown()`, so Astro never populated the `rendered` field. Starlight reads `rendered` to fill `sl-markdown-content` — without it every page built with an empty content area.
- **Empty sidebar**: `autogenerate: { directory: "." }` was taken literally. Starlight matches by `filePath.startsWith(directory + "/")`, and our loader stores paths as `"../packages/clients-docs/content/github.md"`. The string `"."` never matched. Fixed by computing the actual relative path from `docs/` to the content package and using that as the `directory` value.
- **Index appearing twice**: `index.md` would show up under the autogenerated Packages group (as well as the static Overview item). `sidebar.hidden: true` keeps the static item and suppresses the duplicate.

## Test plan

- [x] Local `pnpm --filter @theholocron/clients-site build` produces 3 pages
- [x] `sl-markdown-content` is populated (body renders)
- [x] Sidebar shows Overview + Packages → GitHub Client
- [ ] Merge triggers deploy-docs workflow → confirm live site matches local build