### PR TITLE
refactor(docs): migrate to createDocsLoader from @theholocron/docs-theme

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/clients-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.0.1",
+    "@theholocron/docs-theme": "^1.1.0",
     "astro": "^7.1.5",
     "gray-matter": "^4.0.3"
   },

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,12 +1,12 @@
-import clientsConfig from "@theholocron/clients-docs";
-import { docsSchema } from "@astrojs/starlight/schema";
-import { defineCollection } from "astro:content";
 import { fileURLToPath } from "node:url";
-import { workspaceDocsLoader } from "./loaders/workspace-docs.ts";
 
-const REPO_SLUG = clientsConfig.slug; // "clients"
+import { docsSchema } from "@astrojs/starlight/schema";
+import clientsConfig from "@theholocron/clients-docs";
+import { createDocsLoader } from "@theholocron/docs-theme/loader";
+import { defineCollection } from "astro:content";
 
-/** Strip the repo-level prefix so entries sit at the site base (/clients/). */
+const REPO_SLUG = clientsConfig.slug;
+
 function localSlug(configSlug: string): string {
 	if (configSlug === REPO_SLUG) return "";
 	if (configSlug.startsWith(`${REPO_SLUG}/`))
@@ -16,7 +16,7 @@ function localSlug(configSlug: string): string {
 
 export const collections = {
 	docs: defineCollection({
-		loader: workspaceDocsLoader([
+		loader: createDocsLoader([
 			{
 				dir: fileURLToPath(
 					new URL(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/clients-docs
       '@theholocron/docs-theme':
-        specifier: ^1.0.1
-        version: 1.0.9(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^1.1.0
+        version: 1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       astro:
         specifier: ^7.1.5
         version: 7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -2388,8 +2388,8 @@ packages:
       '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^21.2.0
 
-  '@theholocron/docs-theme@1.0.9':
-    resolution: {integrity: sha512-VTq25N/yD1ryGtROaIfGPR7Jvxtn45AsXIItwnMR1zeWrz2oKnAau0XG53bmKSMV7o3myoRZ7Br65E10qoxUQw==}
+  '@theholocron/docs-theme@1.1.0':
+    resolution: {integrity: sha512-UI9NvBg5L5v3HRQ6kVmT4Pjy8SQ2Du+8b1AslERF/fTtngxapl68NEPCcBc+YwVsg8xB87I6t3UMTdDaqAiAzQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
@@ -7512,10 +7512,11 @@ snapshots:
       '@commitlint/cli': 21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@5.9.3)
       '@commitlint/config-conventional': 21.2.0
 
-  '@theholocron/docs-theme@1.0.9(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
       astro: 7.1.5(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      gray-matter: 4.0.3
 
   '@theholocron/eslint-config@7.6.1(@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0))(globals@17.8.0)(typescript-eslint@8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))':
     dependencies:


### PR DESCRIPTION
Replaces the bespoke `docs/src/loaders/workspace-docs.ts` with `createDocsLoader` from `@theholocron/docs-theme@1.1.0`. Bumps `docs-theme` from `^1.0.1` to `^1.1.0`.

The shared loader is identical in behaviour — `walk`, `computeId`, `renderMarkdown`, `generateDigest` — but lives in one place and is tested there.