### PR TITLE
chore: add docs/dist/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ dist
 
 # Astro generated files
 docs/.astro/
+docs/dist/
 
 # Generated test output — not useful in version control
 test-report.junit.xml


### PR DESCRIPTION
## Summary

Adds `docs/dist/` alongside `docs/.astro/` in `.gitignore` for consistency with the rest of the org (skills was the only repo that had both; all others only had `.astro/`).

Refs theholocron/holocron#288