### PR TITLE
docs: 📝 replace npm install with pnpm add in READMEs and docs content

### DIFF
--- a/packages/clients-docs/content/clerk.md
+++ b/packages/clients-docs/content/clerk.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Clerk user management API, built on @theh
 ## Install
 
 ```bash
-npm i @theholocron/clerk-client
+pnpm add @theholocron/clerk-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/confluence.md
+++ b/packages/clients-docs/content/confluence.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Confluence Cloud REST API, built on @theh
 ## Install
 
 ```bash
-npm i @theholocron/confluence-client
+pnpm add @theholocron/confluence-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/doppler.md
+++ b/packages/clients-docs/content/doppler.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Doppler secrets manager API, built on @th
 ## Install
 
 ```bash
-npm i @theholocron/doppler-client
+pnpm add @theholocron/doppler-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/github.md
+++ b/packages/clients-docs/content/github.md
@@ -8,7 +8,7 @@ description: TypeScript client for the GitHub REST API, built on @theholocron/ht
 ## Install
 
 ```bash
-npm i @theholocron/github-client
+pnpm add @theholocron/github-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/google.md
+++ b/packages/clients-docs/content/google.md
@@ -8,7 +8,7 @@ description: TypeScript client for Google Workspace APIs (Docs and Sheets), buil
 ## Install
 
 ```bash
-npm i @theholocron/google-client
+pnpm add @theholocron/google-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/http.md
+++ b/packages/clients-docs/content/http.md
@@ -8,7 +8,7 @@ description: Shared HTTP primitives used by all @theholocron clients.
 ## Install
 
 ```bash
-npm i @theholocron/http-client
+pnpm add @theholocron/http-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/index.md
+++ b/packages/clients-docs/content/index.md
@@ -31,7 +31,7 @@ resolution, base URL construction, and normalised error responses.
 Each package is published independently to npm:
 
 ```bash
-npm i @theholocron/github-client
+pnpm add @theholocron/github-client
 ```
 
 All packages follow the same lockstep versioning — see the

--- a/packages/clients-docs/content/infisical.md
+++ b/packages/clients-docs/content/infisical.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Infisical secrets manager API, built on @
 ## Install
 
 ```bash
-npm i @theholocron/infisical-client
+pnpm add @theholocron/infisical-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/jira.md
+++ b/packages/clients-docs/content/jira.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Jira Cloud REST API, built on @theholocro
 ## Install
 
 ```bash
-npm i @theholocron/jira-client
+pnpm add @theholocron/jira-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/neon.md
+++ b/packages/clients-docs/content/neon.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Neon serverless Postgres API, built on @t
 ## Install
 
 ```bash
-npm i @theholocron/neon-client
+pnpm add @theholocron/neon-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/postman.md
+++ b/packages/clients-docs/content/postman.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Postman API, built on @theholocron/http-c
 ## Install
 
 ```bash
-npm i @theholocron/postman-client
+pnpm add @theholocron/postman-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/vercel.md
+++ b/packages/clients-docs/content/vercel.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Vercel REST API, built on @theholocron/ht
 ## Install
 
 ```bash
-npm i @theholocron/vercel-client
+pnpm add @theholocron/vercel-client
 ```
 
 ## Usage

--- a/packages/clients-docs/content/zendesk.md
+++ b/packages/clients-docs/content/zendesk.md
@@ -8,7 +8,7 @@ description: TypeScript client for the Zendesk REST API, built on @theholocron/h
 ## Install
 
 ```bash
-npm i @theholocron/zendesk-client
+pnpm add @theholocron/zendesk-client
 ```
 
 ## Usage

--- a/packages/github-client/README.md
+++ b/packages/github-client/README.md
@@ -5,7 +5,7 @@ TypeScript client for the GitHub REST API, built on `@theholocron/http-client`.
 ## Install
 
 ```bash
-npm i @theholocron/github-client
+pnpm add @theholocron/github-client
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Replaces \`npm install --save-dev\` / \`npm i -D\` / \`npm i\` with \`pnpm add\` in all package READMEs and docs content files.