### PR TITLE
ci: 👷 add test-report.junit.xml to turbo test task outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,7 @@
     },
     "test": {
       "inputs": ["src/**", "vitest.config.ts", "package.json"],
-      "outputs": [],
+      "outputs": ["test-report.junit.xml"],
       "dependsOn": ["^build"]
     },
     "test:coverage": {


### PR DESCRIPTION
Adds `test-report.junit.xml` to the turbo `test` task outputs so the file is cached and restored on cache hits, preventing the Codecov 'JUnit XML file not found' warning on docs-only PRs. Refs theholocron/holocron#288