### PR TITLE
chore: 🔧 replace inline version-bump script with pnpm exec holocron

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -1,26 +1,8 @@
 import { defineConfig } from "@theholocron/semantic-release-config";
 
-const packages = [
-	"packages/clerk-client",
-	"packages/clients-docs",
-	"packages/confluence-client",
-	"packages/doppler-client",
-	"packages/github-client",
-	"packages/google-client",
-	"packages/http-client",
-	"packages/infisical-client",
-	"packages/jira-client",
-	"packages/neon-client",
-	"packages/postman-client",
-	"packages/vercel-client",
-	"packages/zendesk-client",
-];
-
-const packageList = packages.map((p) => `'${p}'`).join(",");
-
 export default defineConfig({
 	exec: {
-		prepareCmd: `node -e "const fs=require('fs'),v='\${nextRelease.version}'; [${packageList}].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});"`,
+		prepareCmd: "pnpm exec holocron npm bump-versions ${nextRelease.version}",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},

--- a/release.config.ts
+++ b/release.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 
 export default defineConfig({
 	exec: {
-		prepareCmd: "pnpm exec holocron npm bump-versions ${nextRelease.version}",
+		prepareCmd:
+			"pnpm exec holocron npm bump-versions ${nextRelease.version}",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
Replaces the fragile inline `node -e` version-bump script (and the now-redundant explicit `packages` array) in `release.config.ts` with `pnpm exec holocron npm bump-versions ${nextRelease.version}`, consistent with `configs`, `skills`, and `themes`. The `defineConfig` default assets already cover `packages/*/package.json`.