### PR TITLE
feat: ✨ add GitHub Pages API to github-client

### DIFF
--- a/packages/github-client/src/__tests__/pages.test.ts
+++ b/packages/github-client/src/__tests__/pages.test.ts
@@ -28,14 +28,18 @@ describe("pages", () => {
 		});
 
 		it("GET /repos/{owner}/{name}/pages returns null when Pages is not enabled (404)", async () => {
-			const { fetch } = stubFetch([{ status: 404, body: { message: "Not Found" } }]);
+			const { fetch } = stubFetch([
+				{ status: 404, body: { message: "Not Found" } },
+			]);
 			const client = createGitHubClient({ token: TOKEN, fetch });
 			const result = await client.pages.getPages(REPO);
 			expect(result).toBeNull();
 		});
 
 		it("GET /repos/{owner}/{name}/pages re-throws non-404 errors", async () => {
-			const { fetch } = stubFetch([{ status: 403, body: { message: "Forbidden" } }]);
+			const { fetch } = stubFetch([
+				{ status: 403, body: { message: "Forbidden" } },
+			]);
 			const client = createGitHubClient({ token: TOKEN, fetch });
 			await expect(client.pages.getPages(REPO)).rejects.toThrow();
 		});
@@ -44,10 +48,20 @@ describe("pages", () => {
 	describe("createPages", () => {
 		it("POST /repos/{owner}/{name}/pages with workflow build type", async () => {
 			const { fetch, calls } = stubFetch([
-				{ status: 201, body: { status: "building", build_type: "workflow", https_enforced: false, custom_domain: null } },
+				{
+					status: 201,
+					body: {
+						status: "building",
+						build_type: "workflow",
+						https_enforced: false,
+						custom_domain: null,
+					},
+				},
 			]);
 			const client = createGitHubClient({ token: TOKEN, fetch });
-			const result = await client.pages.createPages(REPO, { build_type: "workflow" });
+			const result = await client.pages.createPages(REPO, {
+				build_type: "workflow",
+			});
 			expect(calls[0]?.url).toContain(PAGES_URL);
 			expect(calls[0]?.method).toBe("POST");
 			expect(calls[0]?.body).toMatchObject({ build_type: "workflow" });
@@ -56,7 +70,15 @@ describe("pages", () => {
 
 		it("POST /repos/{owner}/{name}/pages with legacy build type and branch source", async () => {
 			const { fetch, calls } = stubFetch([
-				{ status: 201, body: { status: "building", build_type: "legacy", https_enforced: false, custom_domain: null } },
+				{
+					status: 201,
+					body: {
+						status: "building",
+						build_type: "legacy",
+						https_enforced: false,
+						custom_domain: null,
+					},
+				},
 			]);
 			const client = createGitHubClient({ token: TOKEN, fetch });
 			await client.pages.createPages(REPO, {

--- a/packages/github-client/src/__tests__/pages.test.ts
+++ b/packages/github-client/src/__tests__/pages.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { createGitHubClient } from "../index.js";
+import { REPO, stubFetch, TOKEN } from "./helpers.js";
+
+const PAGES_URL = `/repos/theholocron/test-repo/pages`;
+
+describe("pages", () => {
+	describe("getPages", () => {
+		it("GET /repos/{owner}/{name}/pages returns Pages data", async () => {
+			const { fetch, calls } = stubFetch([
+				{
+					body: {
+						status: "built",
+						build_type: "workflow",
+						https_enforced: true,
+						custom_domain: "docs.theholocron.dev",
+					},
+				},
+			]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			const result = await client.pages.getPages(REPO);
+			expect(calls[0]?.url).toContain(PAGES_URL);
+			expect(calls[0]?.method).toBe("GET");
+			expect(result?.build_type).toBe("workflow");
+			expect(result?.custom_domain).toBe("docs.theholocron.dev");
+			expect(result?.https_enforced).toBe(true);
+		});
+
+		it("GET /repos/{owner}/{name}/pages returns null when Pages is not enabled (404)", async () => {
+			const { fetch } = stubFetch([{ status: 404, body: { message: "Not Found" } }]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			const result = await client.pages.getPages(REPO);
+			expect(result).toBeNull();
+		});
+
+		it("GET /repos/{owner}/{name}/pages re-throws non-404 errors", async () => {
+			const { fetch } = stubFetch([{ status: 403, body: { message: "Forbidden" } }]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			await expect(client.pages.getPages(REPO)).rejects.toThrow();
+		});
+	});
+
+	describe("createPages", () => {
+		it("POST /repos/{owner}/{name}/pages with workflow build type", async () => {
+			const { fetch, calls } = stubFetch([
+				{ status: 201, body: { status: "building", build_type: "workflow", https_enforced: false, custom_domain: null } },
+			]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			const result = await client.pages.createPages(REPO, { build_type: "workflow" });
+			expect(calls[0]?.url).toContain(PAGES_URL);
+			expect(calls[0]?.method).toBe("POST");
+			expect(calls[0]?.body).toMatchObject({ build_type: "workflow" });
+			expect(result.build_type).toBe("workflow");
+		});
+
+		it("POST /repos/{owner}/{name}/pages with legacy build type and branch source", async () => {
+			const { fetch, calls } = stubFetch([
+				{ status: 201, body: { status: "building", build_type: "legacy", https_enforced: false, custom_domain: null } },
+			]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			await client.pages.createPages(REPO, {
+				build_type: "legacy",
+				source: { branch: "gh-pages", path: "/" },
+			});
+			expect(calls[0]?.method).toBe("POST");
+			expect(calls[0]?.body).toMatchObject({
+				build_type: "legacy",
+				source: { branch: "gh-pages", path: "/" },
+			});
+		});
+	});
+
+	describe("updatePages", () => {
+		it("PUT /repos/{owner}/{name}/pages updates build type", async () => {
+			const { fetch, calls } = stubFetch([{ status: 204 }]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			await client.pages.updatePages(REPO, { build_type: "workflow" });
+			expect(calls[0]?.url).toContain(PAGES_URL);
+			expect(calls[0]?.method).toBe("PUT");
+			expect(calls[0]?.body).toMatchObject({ build_type: "workflow" });
+		});
+
+		it("PUT /repos/{owner}/{name}/pages updates cname and https", async () => {
+			const { fetch, calls } = stubFetch([{ status: 204 }]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			await client.pages.updatePages(REPO, {
+				build_type: "workflow",
+				cname: "docs.theholocron.dev",
+				https_enforced: true,
+			});
+			expect(calls[0]?.body).toMatchObject({
+				cname: "docs.theholocron.dev",
+				https_enforced: true,
+			});
+		});
+
+		it("PUT /repos/{owner}/{name}/pages can clear cname", async () => {
+			const { fetch, calls } = stubFetch([{ status: 204 }]);
+			const client = createGitHubClient({ token: TOKEN, fetch });
+			await client.pages.updatePages(REPO, { cname: null });
+			expect(calls[0]?.body).toMatchObject({ cname: null });
+		});
+	});
+});

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -33,7 +33,12 @@ export type {
 } from "./issues/issues.js";
 export type { GitHubLabel } from "./labels/labels.js";
 export type { GitHubContents, GitHubRepo } from "./repos/repos.js";
-export type { GitHubPages, CreatePagesPayload, UpdatePagesPayload, PagesBuildType } from "./pages/pages.js";
+export type {
+	GitHubPages,
+	CreatePagesPayload,
+	UpdatePagesPayload,
+	PagesBuildType,
+} from "./pages/pages.js";
 export type { GitHubRuleset } from "./rulesets/rulesets.js";
 export type { GitHubPublicKey, SecretScope } from "./secrets/secrets.js";
 export type { CodeScanningSetupResult } from "./security/security.js";

--- a/packages/github-client/src/index.ts
+++ b/packages/github-client/src/index.ts
@@ -3,6 +3,7 @@ import { environments } from "./environments/environments.js";
 import { git } from "./git/git.js";
 import { issues } from "./issues/issues.js";
 import { labels } from "./labels/labels.js";
+import { pages } from "./pages/pages.js";
 import { properties } from "./properties/properties.js";
 import { repos } from "./repos/repos.js";
 import { rulesets } from "./rulesets/rulesets.js";
@@ -32,6 +33,7 @@ export type {
 } from "./issues/issues.js";
 export type { GitHubLabel } from "./labels/labels.js";
 export type { GitHubContents, GitHubRepo } from "./repos/repos.js";
+export type { GitHubPages, CreatePagesPayload, UpdatePagesPayload, PagesBuildType } from "./pages/pages.js";
 export type { GitHubRuleset } from "./rulesets/rulesets.js";
 export type { GitHubPublicKey, SecretScope } from "./secrets/secrets.js";
 export type { CodeScanningSetupResult } from "./security/security.js";
@@ -51,6 +53,7 @@ export function createGitHubClient(opts: GitHubClientOptions) {
 		git: git(rest),
 		issues: issues(rest),
 		labels: labels(rest),
+		pages: pages(rest),
 		properties: properties(rest),
 		repos: repos(rest),
 		rulesets: rulesets(rest),

--- a/packages/github-client/src/pages/pages.ts
+++ b/packages/github-client/src/pages/pages.ts
@@ -1,0 +1,62 @@
+import { ProviderApiError } from "@theholocron/http-client";
+
+import type { RestClient } from "../utils.js";
+import { repoBase } from "../utils.js";
+
+export type PagesBuildType = "workflow" | "legacy";
+
+export interface GitHubPages {
+	status: "built" | "building" | "errored" | "unknown" | null;
+	build_type: PagesBuildType | null;
+	source?: { branch: string; path: string };
+	https_enforced: boolean;
+	custom_domain: string | null;
+}
+
+export interface CreatePagesPayload {
+	build_type: PagesBuildType;
+	/** Required when build_type is "legacy". */
+	source?: { branch: string; path: string };
+}
+
+export interface UpdatePagesPayload {
+	build_type?: PagesBuildType;
+	source?: { branch: string; path: string };
+	cname?: string | null;
+	https_enforced?: boolean;
+}
+
+export function pages(rest: RestClient) {
+	return {
+		/** Returns null when Pages is not yet enabled (404). */
+		getPages: async (repo: string): Promise<GitHubPages | null> => {
+			try {
+				return await rest.request<GitHubPages>(`${repoBase(repo)}/pages`);
+			} catch (err) {
+				if (err instanceof ProviderApiError && err.status === 404) return null;
+				throw err;
+			}
+		},
+
+		/**
+		 * Enables Pages for the first time.
+		 * Throws on all errors except 409 Conflict (already enabled — callers
+		 * should catch that and fall through to updatePages).
+		 */
+		createPages: (repo: string, payload: CreatePagesPayload): Promise<GitHubPages> =>
+			rest.request<GitHubPages>(`${repoBase(repo)}/pages`, {
+				method: "POST",
+				body: payload,
+			}),
+
+		/**
+		 * Updates Pages settings on an existing site (build type, cname, https).
+		 * GitHub returns 204 No Content.
+		 */
+		updatePages: (repo: string, payload: UpdatePagesPayload): Promise<void> =>
+			rest.request<void>(`${repoBase(repo)}/pages`, {
+				method: "PUT",
+				body: payload,
+			}),
+	};
+}

--- a/packages/github-client/src/pages/pages.ts
+++ b/packages/github-client/src/pages/pages.ts
@@ -31,9 +31,12 @@ export function pages(rest: RestClient) {
 		/** Returns null when Pages is not yet enabled (404). */
 		getPages: async (repo: string): Promise<GitHubPages | null> => {
 			try {
-				return await rest.request<GitHubPages>(`${repoBase(repo)}/pages`);
+				return await rest.request<GitHubPages>(
+					`${repoBase(repo)}/pages`,
+				);
 			} catch (err) {
-				if (err instanceof ProviderApiError && err.status === 404) return null;
+				if (err instanceof ProviderApiError && err.status === 404)
+					return null;
 				throw err;
 			}
 		},
@@ -43,7 +46,10 @@ export function pages(rest: RestClient) {
 		 * Throws on all errors except 409 Conflict (already enabled — callers
 		 * should catch that and fall through to updatePages).
 		 */
-		createPages: (repo: string, payload: CreatePagesPayload): Promise<GitHubPages> =>
+		createPages: (
+			repo: string,
+			payload: CreatePagesPayload,
+		): Promise<GitHubPages> =>
 			rest.request<GitHubPages>(`${repoBase(repo)}/pages`, {
 				method: "POST",
 				body: payload,
@@ -53,7 +59,10 @@ export function pages(rest: RestClient) {
 		 * Updates Pages settings on an existing site (build type, cname, https).
 		 * GitHub returns 204 No Content.
 		 */
-		updatePages: (repo: string, payload: UpdatePagesPayload): Promise<void> =>
+		updatePages: (
+			repo: string,
+			payload: UpdatePagesPayload,
+		): Promise<void> =>
 			rest.request<void>(`${repoBase(repo)}/pages`, {
 				method: "PUT",
 				body: payload,


### PR DESCRIPTION
## Summary

Adds a `pages` module to `@theholocron/github-client` with three methods:

- `getPages(repo)` — GET current Pages state; returns `null` on 404 (not yet enabled)
- `createPages(repo, payload)` — POST to enable Pages for the first time
- `updatePages(repo, payload)` — PUT to update build type, cname, and https enforcement

Follows the same pattern as every other module in the client (`security`, `repos`, etc.).

## Usage

```ts
const client = createGitHubClient({ token: HOLOCRON_DEPLOY_TOKEN });

const existing = await client.pages.getPages("owner/repo");
if (!existing) await client.pages.createPages("owner/repo", { build_type: "workflow" });
await client.pages.updatePages("owner/repo", {
  build_type: "workflow",
  cname: "docs.example.com",
  https_enforced: true,
});
```

## Required by

`theholocron/holocron` PR `feat/docs-pages-config` — merge this first, release a new version, then bump the catalog there.