### PR TITLE
test: ci storybook job (debug — do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: theholocron/.github/.github/workflows/test.yml@main
+    uses: theholocron/.github/.github/workflows/test.yml@test/add-storybook-job
     secrets: inherit


### PR DESCRIPTION
**Debug PR — do not merge.**

Testing whether adding the `storybook` job back to the reusable `test.yml` causes `startup_failure`.

- `.github` test branch: `test/add-storybook-job`
- This PR temporarily points the thin caller at that branch instead of `@main`
- Job added: `storybook` (conditional on `inputs.run-storybook`, default `false`; no `GITHUB_TOKEN` usage)

Watch the **Test / Run tests and collect coverage** check — if it `startup_failure`s, even adding an input + a conditional job breaks things. If it passes, move to the next job.

Part of the investigation from theholocron/holocron#315.