### PR TITLE
test: ci interaction-and-accessibility job (debug — do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: theholocron/.github/.github/workflows/test.yml@main
+    uses: theholocron/.github/.github/workflows/test.yml@test/add-interaction-job
     secrets: inherit


### PR DESCRIPTION
**Debug PR — do not merge.**

Testing whether adding the `interaction-and-accessibility` job causes `startup_failure`.

- `.github` test branch: `test/add-interaction-job`
- Builds on `test/add-storybook-job` — includes both `storybook` and `interaction-and-accessibility` jobs
- Job added: `interaction-and-accessibility` (conditional on `inputs.run-interaction`, default `false`; no `GITHUB_TOKEN` usage, `contents: read` only)

PR #258 confirmed `storybook` is clean. This checks `interaction-and-accessibility`.

Part of the investigation from theholocron/holocron#315.