### PR TITLE
test: ci visual-and-composition job (debug — do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: theholocron/.github/.github/workflows/test.yml@main
+    uses: theholocron/.github/.github/workflows/test.yml@test/add-chromatic-job
     secrets: inherit


### PR DESCRIPTION
**Debug PR — do not merge.**

Testing whether adding the `visual-and-composition` (Chromatic) job causes `startup_failure`.

- `.github` test branch: `test/add-chromatic-job`
- Builds on `test/add-interaction-job` — includes `storybook`, `interaction-and-accessibility`, and `visual-and-composition`
- Job added: `visual-and-composition` — **prime suspect**: uses `${{ secrets.GITHUB_TOKEN }}` (not declared in `workflow_call.secrets`) and `statuses: write` permission

PRs #258 and #259 confirmed the first two jobs are clean. This isolates the Chromatic job.

Part of the investigation from theholocron/holocron#315.