### PR TITLE
test: ci chromatic with github.token fix (debug — do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: theholocron/.github/.github/workflows/test.yml@main
+    uses: theholocron/.github/.github/workflows/test.yml@test/chromatic-github-token
     secrets: inherit


### PR DESCRIPTION
**Debug PR — do not merge.**

Bisecting the `visual-and-composition` hang (found in PR #260).

Two suspects in that job:
1. `${{ secrets.GITHUB_TOKEN }}` not declared in `workflow_call.secrets`
2. `statuses: write` permission

This PR tests suspect #1: replaces `token: ${{ secrets.GITHUB_TOKEN }}` with `token: ${{ github.token }}` while keeping `statuses: write` unchanged.

- If this passes → `secrets.GITHUB_TOKEN` in a reusable workflow was the bug; fix is `github.token`
- If this still hangs → `statuses: write` is the issue; next step is to remove that permission

Part of the investigation from theholocron/holocron#315.