### PR TITLE
test: ci chromatic without statuses:write (debug — do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: theholocron/.github/.github/workflows/test.yml@main
+    uses: theholocron/.github/.github/workflows/test.yml@test/chromatic-no-statuses
     secrets: inherit


### PR DESCRIPTION
**Debug PR — do not merge.**

Bisecting the `visual-and-composition` hang — second bisect step.

PR #261 showed `github.token` didn't fix the hang, so `statuses: write` is now the suspect.

Hypothesis: GitHub validates permissions for ALL jobs at workflow startup, even conditionally skipped ones. If `statuses: write` isn't granted by the caller, the whole workflow fails to start.

This PR removes `statuses: write` from `visual-and-composition` (keeps `contents: read` only) while leaving everything else the same as #261.

- If this passes → `statuses: write` in a called workflow is the culprit when the caller doesn't grant it
- If this still hangs → something else entirely

Part of the investigation from theholocron/holocron#315.