### PR TITLE
test: ci user-flow job (debug — do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: theholocron/.github/.github/workflows/test.yml@main
+    uses: theholocron/.github/.github/workflows/test.yml@test/add-user-flow-job
     secrets: inherit


### PR DESCRIPTION
**Debug PR — do not merge.**

Testing whether the `user-flow` (Cypress) job causes `startup_failure`.

- `.github` test branch: `test/add-user-flow-job`
- Builds on `test/chromatic-no-statuses` (working visual-and-composition) + adds `user-flow`
- Suspects: `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` as env var, `matrix: containers: [1, 2]`

Previous findings: `storybook` ✓, `interaction-and-accessibility` ✓, `visual-and-composition` without `statuses: write` ✓.

Part of the investigation from theholocron/holocron#315.