### PR TITLE
chore: ⬆️ bump @theholocron/cli to ^3.10.0 and run holocron setup

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Audit
 
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Deploy Docs
 
 on: # yamllint disable-line rule:truthy
@@ -9,6 +9,7 @@ on: # yamllint disable-line rule:truthy
     branches: [main]
     paths:
       - docs/**
+      - packages/clients-docs/**
   workflow_dispatch:
 
 concurrency:
@@ -24,4 +25,6 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     uses: theholocron/.github/.github/workflows/deploy-docs.yml@main
+    with:
+      name: clients
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Release
 
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  statuses: write
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -103,10 +103,10 @@ service-account*.json
 
 # managed by holocron setup — skills
 /.agents/skills/
+/.claude/skills/turborepo
 /.claude/skills/git-safety
 /.claude/skills/pr-workflow
 /.claude/skills/commit-standards
 /.claude/skills/security-review
 /.claude/skills/holocron-skill-client
-/.claude/skills/turborepo
 # end managed by holocron setup — skills

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,14 +65,14 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: ^3.8.3
-      version: 3.8.3
+      specifier: ^3.10.0
+      version: 3.10.0
     '@theholocron/holocron-config':
       specifier: ^7.7.0
       version: 7.8.1
     '@theholocron/holocron-plugin-github':
-      specifier: ^3.8.3
-      version: 3.8.3
+      specifier: ^3.10.0
+      version: 3.10.0
 
 overrides:
   '@commitlint/config-conventional': ^21.2.0
@@ -104,7 +104,7 @@ importers:
         version: 10.0.1(semantic-release@25.0.8(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
+        version: 3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
       '@theholocron/commitlint-config':
         specifier: 'catalog:'
         version: 7.8.1(@commitlint/cli@21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)
@@ -113,10 +113,10 @@ importers:
         version: 7.7.0(@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0))(globals@17.8.0)(typescript-eslint@8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:holocron
-        version: 7.8.1(@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))
+        version: 7.8.1(@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 3.8.3(@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))
+        version: 3.10.0(@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))
       '@theholocron/lint-staged-config':
         specifier: 'catalog:'
         version: 7.8.1(husky@9.1.7)(lint-staged@16.4.0)
@@ -2524,8 +2524,8 @@ packages:
     peerDependencies:
       astro: '>=5.0.0'
 
-  '@theholocron/cli@3.8.3':
-    resolution: {integrity: sha512-W+bYpVHLQZJfnKB1Z6bEY7xiaCMWv4AirxRAznE0nibQ5B6LnOgLcl5+E+Yyn5T0D6l+5x+tXmPwhuwk0Yj1wQ==}
+  '@theholocron/cli@3.10.0':
+    resolution: {integrity: sha512-/C7g95njivFGAN1FCamwPeOZBnoQarDnnTqhVzsmKpjqnx6tetTjpUBfwltJFRAVmVfzN2Zv0HWeZRgNia1DXg==}
     hasBin: true
 
   '@theholocron/commitlint-config@7.8.1':
@@ -2581,24 +2581,15 @@ packages:
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
 
-  '@theholocron/holocron-plugin-github@3.8.3':
-    resolution: {integrity: sha512-nZ7bybHR5dkTnt4VV9WytBY59O7tPlhSg4jRqu0WqvONBwPFXaDtJZB5NDaFaz1XXl2mQ/iHQWfyjHLlCu4CAA==}
+  '@theholocron/holocron-plugin-github@3.10.0':
+    resolution: {integrity: sha512-d+BBxLco8cO7X1nBFWDbiCUmJTxd3Aw9uzR731OFYfo/qHxLyPj+3+3KYoQQLt7/mgQHEG4JoTeKTsVF9FIa7g==}
     peerDependencies:
-      '@theholocron/cli': 3.8.3
+      '@theholocron/cli': 3.10.0
       '@theholocron/github-client': ^1.6.0
 
   '@theholocron/http-client@0.11.5':
     resolution: {integrity: sha512-FLQS8pW8QIYjY18paJF+evjNn7FApXJ+Z+PWmgFD1gKea+jXkVv8S8ihvSvES8kLmqKtDoUKK17yYgdeg8VHsg==}
     engines: {node: '>=22.0.0'}
-
-  '@theholocron/http-client@1.5.3':
-    resolution: {integrity: sha512-qLPSGlTtv+1uVCoBCKQ470M1+/hXbPozmpUvoBBymYBS90cNB9BBdkiu8PN5w1CfmrO1UYOPCaq+EcZVZI9PIg==}
-    engines: {node: '>=22.0.0'}
-    peerDependencies:
-      vitest: '>=4.0.0'
-    peerDependenciesMeta:
-      vitest:
-        optional: true
 
   '@theholocron/http-client@1.6.0':
     resolution: {integrity: sha512-dYWvKCcSVB1B71JsxWSxebVoyWxQiMouCGcoApeNK8WBmF03tSJVmLztdyGqwXEmq7codGCuW/hXj3qiHph1/g==}
@@ -7808,13 +7799,13 @@ snapshots:
     dependencies:
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)':
+  '@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
       '@napi-rs/keyring': 1.3.0
       '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client': 1.6.0(vitest@4.1.10)
-      '@theholocron/http-client': 1.5.3(vitest@4.1.10)
+      '@theholocron/http-client': 1.6.0(vitest@4.1.10)
       chalk: 6.0.0
       ora: 9.4.1
       tsx: 4.22.4
@@ -7854,21 +7845,17 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-config@7.8.1(@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))':
+  '@theholocron/holocron-config@7.8.1(@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
+      '@theholocron/cli': 3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
 
-  '@theholocron/holocron-plugin-github@3.8.3(@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))':
+  '@theholocron/holocron-plugin-github@3.10.0(@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
+      '@theholocron/cli': 3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
       '@theholocron/github-client': 1.6.0(vitest@4.1.10)
       libsodium-wrappers: 0.8.4
 
   '@theholocron/http-client@0.11.5': {}
-
-  '@theholocron/http-client@1.5.3(vitest@4.1.10)':
-    optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@theholocron/http-client@1.6.0(vitest@4.1.10)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,6 @@ catalog:
 
 catalogs:
   holocron:
-    '@theholocron/cli': ^3.8.3
+    '@theholocron/cli': ^3.10.0
     '@theholocron/holocron-config': ^7.7.0
-    '@theholocron/holocron-plugin-github': ^3.8.3
+    '@theholocron/holocron-plugin-github': ^3.10.0


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/cli` and `@theholocron/holocron-plugin-github` to `^3.10.0`
- Runs `holocron setup` to apply the updated templates
- Key change: adds `statuses: write` to the `test.yml` caller permissions, fixing `startup_failure` on all PRs caused by the `visual-and-composition` job in the reusable `test.yml@main` requiring that permission

Root cause diagnosed in theholocron/holocron#315; fix landed in theholocron/holocron#316.